### PR TITLE
feat(security): Spring Security 초기 설정 구성

### DIFF
--- a/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
+++ b/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package org.nodystudio.nodybackend.config;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -16,16 +17,23 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
 
-import static org.springframework.security.config.Customizer.withDefaults;
-
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
+    // --- 공통 빈 정의 ---
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // --- 개발 환경(dev) 보안 설정 ---
+    @Bean
+    @Profile("dev")
+    public SecurityFilterChain devSecurityFilterChain(HttpSecurity http,
+            CorsConfigurationSource corsConfigurationSource) throws Exception {
         http
-                .cors(withDefaults()) // CORS 설정 추가
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
@@ -33,28 +41,55 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(PathRequest.toH2Console()).permitAll()
                         .anyRequest().permitAll())
-                .headers(headers -> headers // H2 콘솔 프레임 허용
+                .headers(headers -> headers
                         .frameOptions(frameOptions -> frameOptions.sameOrigin()));
 
         return http.build();
     }
 
+    // --- 프로덕션 환경(prod) 보안 설정 ---
     @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+    @Profile("prod")
+    public SecurityFilterChain prodSecurityFilterChain(HttpSecurity http,
+            CorsConfigurationSource corsConfigurationSource) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
+                // .csrf(csrf ->
+                // csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())) //
+                // CSRF 보호 활성화 (SPA + 토큰 방식 고려)
+                .csrf(AbstractHttpConfigurer::disable) // Stateless API + 토큰 인증 시 비활성화 고려
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize
+                        // .requestMatchers("/api/public/**", "/auth/**").permitAll() // 인증 불필요 경로
+                        // .requestMatchers("/api/admin/**").hasRole("ADMIN") // 관리자 권한 필요 경로
+                        .anyRequest().authenticated())
+                // .requiresChannel(channel -> channel // HTTPS 강제 (프로덕션 환경에서 SSL 설정 후 활성화)
+                // .anyRequest().requiresSecure()
+                // )
+                .headers(headers -> headers // 보안 헤더 강화
+                        .frameOptions(frameOptions -> frameOptions.deny())
+                        .contentSecurityPolicy(csp -> csp.policyDirectives("default-src 'self'"))
+                        .httpStrictTransportSecurity(hsts -> hsts.includeSubDomains(true).maxAgeInSeconds(31536000)));
+
+        return http.build();
     }
 
+    // --- 공통 CORS 설정 ---
+    // TODO: 프로덕션 환경에서는 허용할 Origin, Method, Header 등을 엄격하게 제한.
+    // TODO: application.yml 또는 환경 변수를 통해 설정을 주입받는 것을 고려
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOrigins(List.of("*")); // 모든 오리진 허용
-        configuration.setAllowedMethods(List.of("*")); // 모든 HTTP 메서드 허용
-        configuration.setAllowedHeaders(List.of("*")); // 모든 헤더 허용
-        configuration.setAllowCredentials(true); // 자격 증명 허용 (필요에 따라 설정)
+        configuration.setAllowedOrigins(List.of("*"));
+        configuration.setAllowedMethods(List.of("*"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration); // 모든 경로에 대해 CORS 설정 적용
+        source.registerCorsConfiguration("/**", configuration);
         return source;
     }
 }


### PR DESCRIPTION
## Spring Security 기본 설정
- SecurityConfig 클래스 추가하여 SecurityFilterChain 빈 정의
- CSRF 보호, Form Login, HTTP Basic 인증 비활성화
- 세션 관리 정책을 STATELESS로 설정
- 개발 환경 H2 콘솔 접근 허용 (`/h2-console/**`)
- 모든 요청 임시 허용 (`anyRequest().permitAll()`): 추후 인증/인가 로직 추가
- BCryptPasswordEncoder를 PasswordEncoder 빈으로 등록

### CORS 설정 추가
프론트엔드 개발 및 API 테스트를 고려하여, 개발 환경에서 모든 오리진, 메서드, 헤더를 허용하도록 CORS 설정을 구성합니다.

- `SecurityConfig`에 `cors()` 설정 추가
- 모든 요청(`/**`)에 대해 와일드카드(`*`)를 사용하는 `CorsConfigurationSource` 빈 정의

close #2 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 애플리케이션 보안을 강화하는 새로운 설정이 도입되었습니다.
	- 업데이트된 구성은 비상태 세션 관리와 안전한 암호화 기능을 제공하여 사용자 데이터 보호를 향상시킵니다.
	- 개발 및 프로덕션 환경을 위한 보안 필터 체인이 설정되었습니다.
	- CORS 설정이 추가되어 다양한 출처의 요청을 허용합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->