### PR TITLE
feat(CI, CD): Github Actions를 통한 CI/CD 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,13 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build with Gradle
+      - name: Build and Test with Gradle
+        env:
+          SPRING_PROFILES_ACTIVE: test
+          OAUTH_GOOGLE_CLIENT_ID: ${{ secrets.OAUTH_GOOGLE_CLIENT_ID }}
+          OAUTH_GOOGLE_CLIENT_SECRET: ${{ secrets.OAUTH_GOOGLE_CLIENT_SECRET }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
         run: ./gradlew build --no-daemon
-
-      - name: Run tests
-        run: ./gradlew test --no-daemon
 
       - name: Generate test report
         uses: dorny/test-reporter@v1
@@ -64,7 +66,7 @@ jobs:
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
-        if: success() && github.event_name == 'pull_request'
+        if: success() && (github.event_name == 'pull_request' || github.event_name == 'push')
         with:
           name: build-artifacts-pr-${{ github.event.pull_request.number }}
           path: build/libs/
@@ -98,10 +100,20 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run checkstyle
+        env:
+          SPRING_PROFILES_ACTIVE: test
+          OAUTH_GOOGLE_CLIENT_ID: ${{ secrets.OAUTH_GOOGLE_CLIENT_ID }}
+          OAUTH_GOOGLE_CLIENT_SECRET: ${{ secrets.OAUTH_GOOGLE_CLIENT_SECRET }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
         run: ./gradlew checkstyleMain checkstyleTest --no-daemon
         continue-on-error: true
 
       - name: Generate documentation
+        env:
+          SPRING_PROFILES_ACTIVE: test
+          OAUTH_GOOGLE_CLIENT_ID: ${{ secrets.OAUTH_GOOGLE_CLIENT_ID }}
+          OAUTH_GOOGLE_CLIENT_SECRET: ${{ secrets.OAUTH_GOOGLE_CLIENT_SECRET }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
         run: ./gradlew smartdoc --no-daemon
         continue-on-error: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           OAUTH_GOOGLE_CLIENT_ID: ${{ secrets.OAUTH_GOOGLE_CLIENT_ID }}
           OAUTH_GOOGLE_CLIENT_SECRET: ${{ secrets.OAUTH_GOOGLE_CLIENT_SECRET }}
           JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
-        run: ./gradlew build --no-daemon
+        run: ./gradlew smartDocOpenAPI build --no-daemon
 
       - name: Generate test report
         uses: dorny/test-reporter@v1
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
-        if: success() && (github.event_name == 'pull_request' || github.event_name == 'push')
+        if: success() && (github.event_name == 'pull_request')
         with:
           name: build-artifacts-pr-${{ github.event.pull_request.number }}
           path: build/libs/
@@ -98,24 +98,6 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-
-      - name: Run checkstyle
-        env:
-          SPRING_PROFILES_ACTIVE: test
-          OAUTH_GOOGLE_CLIENT_ID: ${{ secrets.OAUTH_GOOGLE_CLIENT_ID }}
-          OAUTH_GOOGLE_CLIENT_SECRET: ${{ secrets.OAUTH_GOOGLE_CLIENT_SECRET }}
-          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
-        run: ./gradlew checkstyleMain checkstyleTest --no-daemon
-        continue-on-error: true
-
-      - name: Generate documentation
-        env:
-          SPRING_PROFILES_ACTIVE: test
-          OAUTH_GOOGLE_CLIENT_ID: ${{ secrets.OAUTH_GOOGLE_CLIENT_ID }}
-          OAUTH_GOOGLE_CLIENT_SECRET: ${{ secrets.OAUTH_GOOGLE_CLIENT_SECRET }}
-          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
-        run: ./gradlew smartdoc --no-daemon
-        continue-on-error: true
 
       - name: Upload documentation
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,114 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - feature/*
+      - fix/*
+      - refactor/*
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build --no-daemon
+
+      - name: Run tests
+        run: ./gradlew test --no-daemon
+
+      - name: Generate test report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: Test Results
+          path: build/test-results/test/*.xml
+          reporter: java-junit
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: build/test-results/
+          retention-days: 7
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        if: success() && github.event_name == 'pull_request'
+        with:
+          name: build-artifacts-pr-${{ github.event.pull_request.number }}
+          path: build/libs/
+          retention-days: 30
+
+  code-quality:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run checkstyle
+        run: ./gradlew checkstyleMain checkstyleTest --no-daemon
+        continue-on-error: true
+
+      - name: Generate documentation
+        run: ./gradlew smartdoc --no-daemon
+        continue-on-error: true
+
+      - name: Upload documentation
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: api-documentation
+          path: src/main/resources/static/
+          retention-days: 30

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,104 @@
+name: Deploy to AWS EBS
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - feature/ci-cd
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: namespace/nody
+  EB_APPLICATION_NAME: nody
+  EB_ENVIRONMENT_NAME: Nody-env
+
+jobs:
+  build:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push the image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+  deploy:
+    name: Deploy to AWS Elastic Beanstalk
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr-deploy
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Generate Dockerrun.aws.json
+        run: |
+          cat <<EOF > Dockerrun.aws.json
+          {
+            "AWSEBDockerrunVersion": "1",
+            "Image": {
+              "Name": "${{ steps.login-ecr-deploy.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}",
+              "Update": "true"
+            },
+            "Ports": [
+              {
+                "ContainerPort": "8080"
+              }
+            ],
+            "Logging": "/var/log/nginx"
+          }
+          EOF
+
+      - name: Create new Elastic Beanstalk Deployment
+        uses: einaregilsson/beanstalk-deploy@v21
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          application_name: ${{ env.EB_APPLICATION_NAME }}
+          environment_name: ${{ env.EB_ENVIRONMENT_NAME }}
+          version_label: ${{ github.sha }}
+          region: ${{ env.AWS_REGION }}
+          deployment_package: Dockerrun.aws.json
+          wait_for_deployment: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,6 @@
 name: Deploy to AWS EBS
 
 on:
-  push:
-    branches:
-      - feature/*
   pull_request:
     types: [closed]
     branches:
@@ -14,12 +11,14 @@ env:
   AWS_REGION: ap-northeast-2
   ECR_REPOSITORY: namespace/nody
   EB_APPLICATION_NAME: nody
+  EB_ENVIRONMENT_NAME: Nody-env
 
 jobs:
   download_artifact_and_build_image:
     name: Download Artifact & Build/Push Docker Image
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && (github.base_ref == 'main' || github.base_ref == 'develop')
+
     steps:
       - name: Checkout PR head commit
         uses: actions/checkout@v4
@@ -31,12 +30,6 @@ jobs:
         with:
           name: build-artifacts-pr-${{ github.event.pull_request.number }}
           path: build/libs
-          # 만약 download-artifact@v4가 다른 워크플로우 실행의 아티팩트를 직접 가져오지 못하는 경우,
-          # (예: PR open/sync 시점의 CI 실행과 PR closed 시점의 배포 실행이 완전히 분리된 컨텍스트일 때)
-          # dawidd6/action-download-artifact@v6 와 같은 커뮤니티 액션 사용을 고려해야 합니다.
-          # pr: ${{ github.event.pull_request.number }}
-          # commit: ${{ github.event.pull_request.head.sha }}
-          # github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -100,7 +93,7 @@ jobs:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           application_name: ${{ env.EB_APPLICATION_NAME }}
-          environment_name: ${{ github.base_ref == 'main' && 'Nody-prod-env' || github.base_ref == 'develop' && 'Nody-dev-env' }}
+          environment_name: ${{ env.EB_ENVIRONMENT_NAME }}
           version_label: pr${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           region: ${{ env.AWS_REGION }}
           deployment_package: Dockerrun.aws.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,36 +3,40 @@ name: Deploy to AWS EBS
 on:
   push:
     branches:
+      - feature/*
+  pull_request:
+    types: [closed]
+    branches:
       - main
       - develop
-      - feature/ci-cd
 
 env:
   AWS_REGION: ap-northeast-2
   ECR_REPOSITORY: namespace/nody
   EB_APPLICATION_NAME: nody
-  EB_ENVIRONMENT_NAME: Nody-env
 
 jobs:
-  build:
-    name: Build and Push Docker Image
+  download_artifact_and_build_image:
+    name: Download Artifact & Build/Push Docker Image
     runs-on: ubuntu-latest
-
+    if: github.event.pull_request.merged == true && (github.base_ref == 'main' || github.base_ref == 'develop')
     steps:
-      - name: Checkout code
+      - name: Checkout PR head commit
         uses: actions/checkout@v4
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
         with:
-          java-version: "21"
-          distribution: "temurin"
+          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      - name: Build with Gradle
-        run: ./gradlew build -x test
+      - name: Download build artifact from PR CI
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-pr-${{ github.event.pull_request.number }}
+          path: build/libs
+          # 만약 download-artifact@v4가 다른 워크플로우 실행의 아티팩트를 직접 가져오지 못하는 경우,
+          # (예: PR open/sync 시점의 CI 실행과 PR closed 시점의 배포 실행이 완전히 분리된 컨텍스트일 때)
+          # dawidd6/action-download-artifact@v6 와 같은 커뮤니티 액션 사용을 고려해야 합니다.
+          # pr: ${{ github.event.pull_request.number }}
+          # commit: ${{ github.event.pull_request.head.sha }}
+          # github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -48,20 +52,17 @@ jobs:
       - name: Build, tag, and push the image to Amazon ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE_TAG: ${{ github.event.pull_request.head.sha }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
-  deploy:
+  deploy_to_ebs:
     name: Deploy to AWS Elastic Beanstalk
     runs-on: ubuntu-latest
-    needs: build
-
+    needs: download_artifact_and_build_image
+    if: github.event.pull_request.merged == true && (github.base_ref == 'main' || github.base_ref == 'develop')
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -74,12 +75,14 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Generate Dockerrun.aws.json
+        env:
+          ECR_REGISTRY_DEPLOY: ${{ steps.login-ecr-deploy.outputs.registry }}
         run: |
           cat <<EOF > Dockerrun.aws.json
           {
             "AWSEBDockerrunVersion": "1",
             "Image": {
-              "Name": "${{ steps.login-ecr-deploy.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}",
+              "Name": "${ECR_REGISTRY_DEPLOY}/${{ env.ECR_REPOSITORY }}:${{ github.event.pull_request.head.sha }}",
               "Update": "true"
             },
             "Ports": [
@@ -97,8 +100,8 @@ jobs:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           application_name: ${{ env.EB_APPLICATION_NAME }}
-          environment_name: ${{ env.EB_ENVIRONMENT_NAME }}
-          version_label: ${{ github.sha }}
+          environment_name: ${{ github.base_ref == 'main' && 'Nody-prod-env' || github.base_ref == 'develop' && 'Nody-dev-env' }}
+          version_label: pr${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           region: ${{ env.AWS_REGION }}
           deployment_package: Dockerrun.aws.json
           wait_for_deployment: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:21.0.7_6-jdk-ubi9-minimal
+
+ARG JAR_FILE=build/libs/*.jar
+
+COPY ${JAR_FILE} app.jar
+
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
+++ b/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package org.nodystudio.nodybackend.config;
 
 import java.util.List;
 import org.nodystudio.nodybackend.security.filter.JwtAuthenticationFilter;
+import org.nodystudio.nodybackend.security.handler.CustomAccessDeniedHandler;
+import org.nodystudio.nodybackend.security.handler.CustomAuthenticationEntryPoint;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
@@ -26,12 +28,18 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final CustomAccessDeniedHandler customAccessDeniedHandler;
+  private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
   @Value("${cors.allowed-origins}")
   private List<String> allowedOrigins;
 
-  public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+  public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
+      CustomAccessDeniedHandler customAccessDeniedHandler,
+      CustomAuthenticationEntryPoint customAuthenticationEntryPoint) {
     this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    this.customAccessDeniedHandler = customAccessDeniedHandler;
+    this.customAuthenticationEntryPoint = customAuthenticationEntryPoint;
   }
 
   // --- 공통 빈 정의 ---
@@ -58,7 +66,15 @@ public class SecurityConfig {
             .requestMatchers("/api/auth/**", "/api/public/**").permitAll()
             .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
             .requestMatchers("/openapi.json").permitAll()
+            // .requestMatchers("/api/test/exceptions/ok", "/api/test/exceptions/not-found",
+            // "/api/test/exceptions/unauthorized", "/api/test/exceptions/forbidden",
+            // "/api/test/exceptions/validation", "/api/test/exceptions/error")
+            // .permitAll()
+            // .requestMatchers("/api/test/exceptions/security-access-test").hasRole("ADMIN")
             .anyRequest().authenticated())
+        .exceptionHandling(exceptions -> exceptions
+            .authenticationEntryPoint(customAuthenticationEntryPoint)
+            .accessDeniedHandler(customAccessDeniedHandler))
         .headers(headers -> headers
             .frameOptions(FrameOptionsConfig::sameOrigin))
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
@@ -83,7 +99,15 @@ public class SecurityConfig {
             .requestMatchers("/api/auth/**", "/api/public/**").permitAll()
             .requestMatchers("/api/admin/**").hasRole("ADMIN")
             .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+            .requestMatchers("/api/test/exceptions/ok", "/api/test/exceptions/not-found",
+                "/api/test/exceptions/unauthorized", "/api/test/exceptions/forbidden",
+                "/api/test/exceptions/validation", "/api/test/exceptions/error")
+            .permitAll()
+            .requestMatchers("/api/test/exceptions/security-access-test").hasRole("ADMIN")
             .anyRequest().authenticated())
+        .exceptionHandling(exceptions -> exceptions
+            .authenticationEntryPoint(customAuthenticationEntryPoint)
+            .accessDeniedHandler(customAccessDeniedHandler))
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         // .requiresChannel(channel -> channel // HTTPS 강제 (프로덕션 환경에서 SSL 설정 후 활성화)
         // .anyRequest().requiresSecure()

--- a/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
+++ b/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package org.nodystudio.nodybackend.config;
 import java.util.List;
 import org.nodystudio.nodybackend.security.filter.JwtAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,6 +26,9 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+  @Value("${cors.allowed-origins}")
+  private List<String> allowedOrigins;
 
   public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
     this.jwtAuthenticationFilter = jwtAuthenticationFilter;
@@ -98,7 +102,7 @@ public class SecurityConfig {
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
 
-    configuration.setAllowedOrigins(List.of("${cors.allowed-origins}"));
+    configuration.setAllowedOrigins(allowedOrigins);
     configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
     configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With"));
     configuration.setExposedHeaders(List.of("Authorization"));

--- a/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
+++ b/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package org.nodystudio.nodybackend.config;
 
 import java.util.List;
+import jakarta.annotation.PostConstruct;
 import org.nodystudio.nodybackend.security.filter.JwtAuthenticationFilter;
 import org.nodystudio.nodybackend.security.handler.CustomAccessDeniedHandler;
 import org.nodystudio.nodybackend.security.handler.CustomAuthenticationEntryPoint;
@@ -42,6 +43,33 @@ public class SecurityConfig {
     this.customAuthenticationEntryPoint = customAuthenticationEntryPoint;
   }
 
+  @PostConstruct
+  public void validateConfiguration() {
+    validateAllowedOrigins();
+  }
+
+  /**
+   * CORS allowed-origins 설정값을 검증합니다.
+   *
+   * @throws IllegalStateException allowedOrigins가 null이거나 비어있거나 유효하지 않은 경우
+   */
+  private void validateAllowedOrigins() {
+    if (allowedOrigins == null) {
+      throw new IllegalStateException(
+          "CORS allowed-origins 설정이 누락되었습니다. application.yaml에서 'cors.allowed-origins' 값을 설정해주세요.");
+    }
+
+    if (allowedOrigins.isEmpty()) {
+      throw new IllegalStateException("CORS allowed-origins 설정이 비어있습니다. 최소 하나 이상의 origin을 설정해주세요.");
+    }
+
+    for (String origin : allowedOrigins) {
+      if (origin == null || origin.trim().isEmpty()) {
+        throw new IllegalStateException("CORS allowed-origins에 유효하지 않은 값이 포함되어 있습니다. 빈 문자열이나 공백은 허용되지 않습니다.");
+      }
+    }
+  }
+
   // --- 공통 빈 정의 ---
   @Bean
   public PasswordEncoder passwordEncoder() {
@@ -66,11 +94,7 @@ public class SecurityConfig {
             .requestMatchers("/api/auth/**", "/api/public/**").permitAll()
             .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
             .requestMatchers("/openapi.json").permitAll()
-            // .requestMatchers("/api/test/exceptions/ok", "/api/test/exceptions/not-found",
-            // "/api/test/exceptions/unauthorized", "/api/test/exceptions/forbidden",
-            // "/api/test/exceptions/validation", "/api/test/exceptions/error")
-            // .permitAll()
-            // .requestMatchers("/api/test/exceptions/security-access-test").hasRole("ADMIN")
+            .requestMatchers("/api/test/exceptions/security-access-test").hasRole("ADMIN")
             .anyRequest().authenticated())
         .exceptionHandling(exceptions -> exceptions
             .authenticationEntryPoint(customAuthenticationEntryPoint)
@@ -99,11 +123,6 @@ public class SecurityConfig {
             .requestMatchers("/api/auth/**", "/api/public/**").permitAll()
             .requestMatchers("/api/admin/**").hasRole("ADMIN")
             .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-            .requestMatchers("/api/test/exceptions/ok", "/api/test/exceptions/not-found",
-                "/api/test/exceptions/unauthorized", "/api/test/exceptions/forbidden",
-                "/api/test/exceptions/validation", "/api/test/exceptions/error")
-            .permitAll()
-            .requestMatchers("/api/test/exceptions/security-access-test").hasRole("ADMIN")
             .anyRequest().authenticated())
         .exceptionHandling(exceptions -> exceptions
             .authenticationEntryPoint(customAuthenticationEntryPoint)

--- a/src/main/java/org/nodystudio/nodybackend/controller/test/ExceptionTestController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/test/ExceptionTestController.java
@@ -76,4 +76,22 @@ public class ExceptionTestController {
   public ResponseEntity<Void> getError() {
     throw new RuntimeException();
   }
+
+  /**
+   * Spring Security 인증 실패 테스트 (401 Unauthorized)
+   * 이 엔드포인트는 인증이 필요하므로 토큰 없이 접근하면 CustomAuthenticationEntryPoint가 호출됩니다.
+   */
+  @GetMapping("/security-auth-test")
+  public ResponseEntity<ApiResponse<?>> getSecurityAuthTest() {
+    return ResponseEntity.ok(ApiResponse.success("인증된 사용자만 볼 수 있는 데이터"));
+  }
+
+  /**
+   * Spring Security 권한 부족 테스트 (403 Forbidden)
+   * 이 엔드포인트는 ADMIN 권한이 필요하므로 일반 사용자가 접근하면 CustomAccessDeniedHandler가 호출됩니다.
+   */
+  @GetMapping("/security-access-test")
+  public ResponseEntity<ApiResponse<?>> getSecurityAccessTest() {
+    return ResponseEntity.ok(ApiResponse.success("ADMIN 권한이 있는 사용자만 볼 수 있는 데이터"));
+  }
 }

--- a/src/main/java/org/nodystudio/nodybackend/domain/user/User.java
+++ b/src/main/java/org/nodystudio/nodybackend/domain/user/User.java
@@ -17,7 +17,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "user", uniqueConstraints = {
+@Table(name = "users", uniqueConstraints = {
     @UniqueConstraint(columnNames = { "provider", "social_id" }),
     @UniqueConstraint(columnNames = "email")
 })

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -46,3 +46,16 @@ jwt:
   secret-key: ${JWT_SECRET_KEY}
   access-token-expiration-minutes: 15
   refresh-token-expiration-days: 7
+
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /swagger-ui.html
+    url: /openapi.json
+    display-request-duration: true
+    groups-order: DESC
+    operations-sorter: alpha
+  api-docs:
+    path: /api-docs
+  show-actuator: true

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -1,0 +1,48 @@
+spring:
+  web:
+    resources:
+      static-locations: classpath:/static/
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    open-in-view: false
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${OAUTH_GOOGLE_CLIENT_ID}
+            client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
+            scope:
+              - profile
+              - email
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
+
+oauth2:
+  redirect:
+    url: https://nodyy.com/oauth/callback
+    allowed-domains: https://api.nodyy.com
+    allowed-redirect-hosts: nodyy
+
+cors:
+  allowed-origins: https://api.nodyy.com
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+  access-token-expiration-minutes: 15
+  refresh-token-expiration-days: 7

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,4 +2,4 @@ spring:
   application:
     name: nody-backend
   profiles:
-    active: dev
+    active: test

--- a/src/test/java/org/nodystudio/nodybackend/config/SecurityConfigTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/config/SecurityConfigTest.java
@@ -1,0 +1,127 @@
+package org.nodystudio.nodybackend.config;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.nodystudio.nodybackend.security.filter.JwtAuthenticationFilter;
+import org.nodystudio.nodybackend.security.handler.CustomAccessDeniedHandler;
+import org.nodystudio.nodybackend.security.handler.CustomAuthenticationEntryPoint;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SecurityConfig 테스트")
+class SecurityConfigTest {
+
+  private SecurityConfig securityConfig;
+  private JwtAuthenticationFilter jwtAuthenticationFilter;
+  private CustomAccessDeniedHandler customAccessDeniedHandler;
+  private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+  @BeforeEach
+  void setUp() {
+    jwtAuthenticationFilter = mock(JwtAuthenticationFilter.class);
+    customAccessDeniedHandler = mock(CustomAccessDeniedHandler.class);
+    customAuthenticationEntryPoint = mock(CustomAuthenticationEntryPoint.class);
+
+    securityConfig = new SecurityConfig(
+        jwtAuthenticationFilter,
+        customAccessDeniedHandler,
+        customAuthenticationEntryPoint);
+  }
+
+  @Test
+  @DisplayName("allowedOrigins가 null인 경우 IllegalStateException 발생")
+  void validateAllowedOrigins_WhenNull_ShouldThrowException() {
+    // given
+    ReflectionTestUtils.setField(securityConfig, "allowedOrigins", null);
+
+    // when & then
+    assertThatThrownBy(() -> securityConfig.validateConfiguration())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("CORS allowed-origins 설정이 누락되었습니다. application.yaml에서 'cors.allowed-origins' 값을 설정해주세요.");
+  }
+
+  @Test
+  @DisplayName("allowedOrigins가 빈 리스트인 경우 IllegalStateException 발생")
+  void validateAllowedOrigins_WhenEmpty_ShouldThrowException() {
+    // given
+    List<String> emptyList = new ArrayList<>();
+    ReflectionTestUtils.setField(securityConfig, "allowedOrigins", emptyList);
+
+    // when & then
+    assertThatThrownBy(() -> securityConfig.validateConfiguration())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("CORS allowed-origins 설정이 비어있습니다. 최소 하나 이상의 origin을 설정해주세요.");
+  }
+
+  @Test
+  @DisplayName("allowedOrigins에 null 값이 포함된 경우 IllegalStateException 발생")
+  void validateAllowedOrigins_WhenContainsNull_ShouldThrowException() {
+    // given
+    List<String> listWithNull = Arrays.asList("http://localhost:3000", null, "https://example.com");
+    ReflectionTestUtils.setField(securityConfig, "allowedOrigins", listWithNull);
+
+    // when & then
+    assertThatThrownBy(() -> securityConfig.validateConfiguration())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("CORS allowed-origins에 유효하지 않은 값이 포함되어 있습니다. 빈 문자열이나 공백은 허용되지 않습니다.");
+  }
+
+  @Test
+  @DisplayName("allowedOrigins에 빈 문자열이 포함된 경우 IllegalStateException 발생")
+  void validateAllowedOrigins_WhenContainsEmptyString_ShouldThrowException() {
+    // given
+    List<String> listWithEmpty = Arrays.asList("http://localhost:3000", "", "https://example.com");
+    ReflectionTestUtils.setField(securityConfig, "allowedOrigins", listWithEmpty);
+
+    // when & then
+    assertThatThrownBy(() -> securityConfig.validateConfiguration())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("CORS allowed-origins에 유효하지 않은 값이 포함되어 있습니다. 빈 문자열이나 공백은 허용되지 않습니다.");
+  }
+
+  @Test
+  @DisplayName("allowedOrigins에 공백만 있는 문자열이 포함된 경우 IllegalStateException 발생")
+  void validateAllowedOrigins_WhenContainsWhitespaceOnly_ShouldThrowException() {
+    // given
+    List<String> listWithWhitespace = Arrays.asList("http://localhost:3000", "   ", "https://example.com");
+    ReflectionTestUtils.setField(securityConfig, "allowedOrigins", listWithWhitespace);
+
+    // when & then
+    assertThatThrownBy(() -> securityConfig.validateConfiguration())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("CORS allowed-origins에 유효하지 않은 값이 포함되어 있습니다. 빈 문자열이나 공백은 허용되지 않습니다.");
+  }
+
+  @Test
+  @DisplayName("유효한 allowedOrigins인 경우 예외가 발생하지 않음")
+  void validateAllowedOrigins_WhenValid_ShouldNotThrowException() {
+    // given
+    List<String> validOrigins = Arrays.asList("http://localhost:3000", "https://example.com",
+        "https://api.example.com");
+    ReflectionTestUtils.setField(securityConfig, "allowedOrigins", validOrigins);
+
+    // when & then - 예외가 발생하지 않아야 함
+    securityConfig.validateConfiguration();
+  }
+
+  @Test
+  @DisplayName("단일 유효한 origin인 경우 예외가 발생하지 않음")
+  void validateAllowedOrigins_WhenSingleValidOrigin_ShouldNotThrowException() {
+    // given
+    List<String> singleOrigin = Collections.singletonList("http://localhost:3000");
+    ReflectionTestUtils.setField(securityConfig, "allowedOrigins", singleOrigin);
+
+    // when & then - 예외가 발생하지 않아야 함
+    securityConfig.validateConfiguration();
+  }
+}


### PR DESCRIPTION
## 주요 기능 및 변경 사항
### CI/CD 파이프라인 (GitHub Actions)
- ci.yml
  - 빌드 및 테스트 자동화 구현 및 보고서 생성
  - 빌드 전 OpenAPI 문서 생성을 위한 smartDocOpenAPI 생성
  - 안전한 작업을 위해 Github Secret을 통한 관리
  - PR에 대한 빌드 아티팩트를 업로드하여 배포시 사용하도록 적용

- deploy.yml
  - main 또는 develop 브랜치에 병합 시 AWS Elastic Beanstalk 자동 배포
  - 빌드된 아티팩트(Jar) 다운로드
  - Amazon ECR로 Docker 이미지 빌드/푸시
  - Dockerrun.aws.json 생성 및 Elastic Beanstalk 배포

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- CI 및 배포 자동화를 위한 GitHub Actions 워크플로우가 추가되었습니다.
	- Dockerfile이 도입되어 컨테이너 이미지 빌드 및 AWS Elastic Beanstalk 배포가 가능해졌습니다.
	- Spring Security 테스트를 위한 인증/인가 테스트 엔드포인트가 추가되었습니다.
	- 테스트 환경용 application-test.yaml 설정 파일이 추가되었습니다.

- **버그 수정**
	- User 엔티티의 테이블명이 "user"에서 "users"로 변경되었습니다.

- **문서**
	- OpenAPI 문서 자동 업로드 및 테스트 리포트 생성 기능이 CI에 포함되었습니다.

- **스타일/환경설정**
	- 기본 활성 프로필이 "dev"에서 "test"로 변경되었습니다.

- **리팩터링**
	- CORS 허용 오리진이 동적으로 설정되도록 개선되었습니다.
	- SecurityConfig에 커스텀 인증/인가 예외 핸들러가 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->