### PR TITLE
fix(security): SecurityConfig의 H2 console settings 삭제

### DIFF
--- a/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
+++ b/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
@@ -90,7 +90,6 @@ public class SecurityConfig {
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(authorize -> authorize
-            .requestMatchers(PathRequest.toH2Console()).permitAll()
             .requestMatchers("/api/auth/**", "/api/public/**").permitAll()
             .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
             .requestMatchers("/openapi.json").permitAll()
@@ -99,8 +98,6 @@ public class SecurityConfig {
         .exceptionHandling(exceptions -> exceptions
             .authenticationEntryPoint(customAuthenticationEntryPoint)
             .accessDeniedHandler(customAccessDeniedHandler))
-        .headers(headers -> headers
-            .frameOptions(FrameOptionsConfig::sameOrigin))
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
     return http.build();


### PR DESCRIPTION
## 📋 Pull Request 요약

### 📝 변경 내용 설명

배포 환경에서 `dev` 프로필 활성화 시 H2 라이브러리가 없어 발생하는 `NoSuchBeanDefinitionException` 오류를 해결합니다.

`SecurityConfig`의 `dev` 프로필 보안 설정에서 H2 콘솔 관련 경로(`PathRequest.toH2Console()`) 및 `frameOptions` 설정을 제거하여, H2 라이브러리가 없는 환경에서도 `dev` 프로필이 정상적으로 동작하도록 수정했습니다.

---

## 🔧 기술적 변경 사항

### 🔐 보안 관련 변경

- [x] 인증/인가 로직 변경
- [ ] JWT 토큰 처리 수정
- [ ] OAuth2 설정 변경
- [ ] CORS 설정 수정
- [ ] 보안 헤더 추가/수정
- [ ] 보안 관련 변경 없음

---

## ✅ 체크리스트

### 📖 문서화

- [ ] API 문서가 업데이트되었습니다 (Swagger/OpenAPI)
- [x] 코드 주석이 적절히 작성되었습니다
- [ ] 변경 사항에 대한 문서를 작성했습니다

### 🔧 설정 및 환경

- [x] 개발 환경에서 정상 동작을 확인했습니다
- [x] 프로덕션 환경 설정을 고려했습니다
- [x] 환경별 설정 파일이 적절히 구성되었습니다 (dev, prod)
- [ ] 의존성 추가 시 버전 충돌을 확인했습니다

---

## 🧪 테스트 결과

### 🔍 테스트 시나리오

1.  `dev` 프로필로 애플리케이션 실행 시 정상적으로 구동되는지 확인
2.  `prod` 프로필로 애플리케이션 실행 시 정상적으로 구동되는지 확인

### 📊 테스트 커버리지

<!-- 테스트 커버리지 정보가 있다면 첨부해주세요 -->

- [ ] 단위 테스트 커버리지: %
- [x] 통합 테스트 완료

---

## 📸 스크린샷 / 로그

<!-- API 테스트 결과, 로그, 또는 UI 변경사항 스크린샷이 있다면 첨부해주세요 -->

**오류 발생 로그 (수정 전)**
```
org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.springframework.boot.autoconfigure.h2.H2ConsoleProperties' available
```

**수정 후 정상 실행 로그**
(정상 실행되므로 별도 로그는 첨부하지 않음)

---

## 🚀 배포 시 주의사항

- `dev` 프로필을 사용하는 배포 환경이 있다면, 이번 배포 이후 애플리케이션이 정상적으로 실행되는지 확인이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - H2 콘솔 경로에 대한 접근 허용이 제거되어, 더 이상 H2 콘솔에 직접 접근할 수 없습니다.  
  - 개발 환경에서 프레임 옵션 관련 보안 설정이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->