### PR TITLE
fix(security): favicon.ico 요청에 대한 인증 오류 해결

### DIFF
--- a/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
+++ b/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
@@ -92,7 +92,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers("/api/auth/**", "/api/public/**").permitAll()
             .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
-            .requestMatchers("/openapi.json").permitAll()
+            .requestMatchers("/openapi.json", "/favicon.ico").permitAll()
             .requestMatchers("/api/test/exceptions/security-access-test").hasRole("ADMIN")
             .anyRequest().authenticated())
         .exceptionHandling(exceptions -> exceptions
@@ -119,7 +119,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers("/api/auth/**", "/api/public/**").permitAll()
             .requestMatchers("/api/admin/**").hasRole("ADMIN")
-            .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+            .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/favicon.ico").permitAll()
             .anyRequest().authenticated())
         .exceptionHandling(exceptions -> exceptions
             .authenticationEntryPoint(customAuthenticationEntryPoint)


### PR DESCRIPTION
## 📋 Pull Request 요약

### 📝 변경 내용 설명

- Spring Security 설정에서 `/favicon.ico` 경로를 허용하여, 브라우저의 자동 요청으로 인한 인증 예외 발생 문제를 해결합니다.

### 🔗 관련 이슈

- 관련 이슈 없음

---

## 🔧 기술적 변경 사항

### 📁 주요 변경 파일

- `src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java`

### 🛠️ API 변경 사항

- API 변경 사항 없음

### 🗄️ 데이터베이스 변경 사항

- [x] 데이터베이스 변경 없음

### 🔐 보안 관련 변경

- [x] 인증/인가 로직 변경
- Spring Security 필터 체인에서 `/favicon.ico` 경로를 인증 없이 통과하도록 허용했습니다.

---

## ✅ 체크리스트

### 🔧 설정 및 환경

- [x] 개발 환경에서 정상 동작을 확인했습니다
- [x] 프로덕션 환경 설정을 고려했습니다
- [x] 환경별 설정 파일이 적절히 구성되었습니다 (dev, prod)

---

## 🧪 테스트 결과

### 🔍 테스트 시나리오

1. 애플리케이션 실행
2. 브라우저에서 임의의 API 엔드포인트 또는 존재하지 않는 경로로 접근
3. 서버 로그에 더 이상 `/favicon.ico` 관련 `InsufficientAuthenticationException` 오류가 발생하지 않음을 확인

---

## 📸 스크린샷 / 로그

**수정 전 오류 로그:**
```
org.springframework.security.authentication.InsufficientAuthenticationException: Full authentication is required to access this resource at org.springframework.security.web.access.ExceptionTranslationFilter.handleAccessDeniedException(ExceptionTranslationFilter.java:199)
```

**수정 후:**
- 해당 오류 로그가 발생하지 않음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 개발 및 운영 환경 모두에서 "/favicon.ico" 경로에 대한 접근이 허용되어 파비콘 관련 접근 문제가 해결되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->