### PR TITLE
fix(security): actuator 엔드포인트 접근 허용

### DIFF
--- a/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
+++ b/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
@@ -92,6 +92,7 @@ public class SecurityConfig {
             .requestMatchers("/api/auth/**", "/api/public/**").permitAll()
             .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
             .requestMatchers("/openapi.json", "/favicon.ico").permitAll()
+            .requestMatchers("/actuator/**").permitAll()
             .requestMatchers("/api/test/exceptions/security-access-test").hasRole("ADMIN")
             .anyRequest().authenticated())
         .exceptionHandling(exceptions -> exceptions
@@ -119,6 +120,7 @@ public class SecurityConfig {
             .requestMatchers("/api/auth/**", "/api/public/**").permitAll()
             .requestMatchers("/api/admin/**").hasRole("ADMIN")
             .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/favicon.ico").permitAll()
+            .requestMatchers("/actuator/**").permitAll()
             .anyRequest().authenticated())
         .exceptionHandling(exceptions -> exceptions
             .authenticationEntryPoint(customAuthenticationEntryPoint)


### PR DESCRIPTION
## 📝 설명

Spring Boot Actuator의 `/actuator/health`와 같은 엔드포인트에 접근할 때 `InsufficientAuthenticationException`이 발생하는 문제를 해결합니다.
Spring Security 설정에서 해당 경로가 인증된 사용자에게만 허용되어 있어 문제가 발생했습니다.
`/actuator/**`를 통해 요청을 허용하여 healthcheck가 진행되도록 해결했습니다.

## ✅ 작업 유형

- [x] 버그 수정 (기능에 영향을 주지 않는 변경)

## 🔨 작업 상세 내용

- `SecurityConfig.java`의 `devSecurityFilterChain`과 `prodSecurityFilterChain`에 다음 권한 설정을 추가했습니다.

```java
  .requestMatchers("/actuator/**").permitAll()
````

- 이를 통해 `dev` 및 `prod` 환경 모두에서 인증 없이 Actuator 엔드포인트에 접근할 수 있도록 허용합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
    - "/actuator/**" 엔드포인트에 대한 접근이 인증 없이 허용됩니다.  
- **기타**
    - 개발 및 운영 환경 모두에 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->