### PR TITLE
fix(auth): 로그인 성공 리다이렉트 URL에서 userId 제거

### DIFF
--- a/src/main/java/org/nodystudio/nodybackend/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/org/nodystudio/nodybackend/security/handler/OAuth2LoginSuccessHandler.java
@@ -123,7 +123,6 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
       String targetUrl = UriComponentsBuilder
           .fromUriString(redirectUrl)
           .queryParam("authSuccess", "true")
-          .queryParam("userId", user.getId())
           .build()
           .toUriString();
 
@@ -162,7 +161,8 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
   }
 
   /**
-   * 리다이렉트 URL이 허용된 도메인인지 검증 도메인 경로('/path')가 포함된 URL도 허용하고, 서브도메인은 보호합니다. 프로토콜(http/https)은 비교에서
+   * 리다이렉트 URL이 허용된 도메인인지 검증 도메인 경로('/path')가 포함된 URL도 허용하고, 서브도메인은 보호합니다.
+   * 프로토콜(http/https)은 비교에서
    * 제외하여 환경 전환 시에도 인증이 유지됩니다.
    *
    * @param url 검증할 URL
@@ -207,7 +207,8 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
    *
    * @param redirectFullHost 리다이렉트 URL의 호스트:포트 또는 호스트 부분.
    * @param redirectHostOnly 리다이렉트 URL의 호스트 부분.
-   * @param rawAllowedDomain 원시 허용 도메인 문자열 (예: "https://example.com:8080", "sub.example.com").
+   * @param rawAllowedDomain 원시 허용 도메인 문자열 (예: "https://example.com:8080",
+   *                         "sub.example.com").
    * @return 리다이렉트 URL이 허용 도메인 패턴과 일치하면 true, 그렇지 않으면 false.
    */
   private boolean domainMatches(String redirectFullHost, String redirectHostOnly,

--- a/src/test/java/org/nodystudio/nodybackend/security/handler/OAuth2LoginSuccessHandlerTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/security/handler/OAuth2LoginSuccessHandlerTest.java
@@ -135,7 +135,7 @@ class OAuth2LoginSuccessHandlerTest {
     assertThat(savedUser.getRefreshTokenExpiry()).isEqualTo(refreshTokenExpiry);
 
     // 2. 리다이렉션 URL 검증
-    String expectedRedirectUrl = redirectUrl + "?authSuccess=true&userId=" + testUser.getId();
+    String expectedRedirectUrl = redirectUrl + "?authSuccess=true";
     assertThat(response.getRedirectedUrl()).isEqualTo(expectedRedirectUrl);
     assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FOUND);
 


### PR DESCRIPTION
## 📋 Pull Request 요약

### 📝 변경 내용 설명

- 소셜 로그인 성공 후, 프론트엔드로 리다이렉트되는 URL의 쿼리 파라미터에서 `userId`를 제거하여 보안을 강화했습니다.

---

## 🔧 기술적 변경 사항

### 📁 주요 변경 파일

- `src/main/java/org/nodystudio/nodybackend/security/handler/OAuth2LoginSuccessHandler.java`
- `src/test/java/org/nodystudio/nodybackend/security/handler/OAuth2LoginSuccessHandlerTest.java`

### 🛠️ API 변경 사항

- API 변경 사항은 없습니다.

### 🗄️ 데이터베이스 변경 사항

- [x] 데이터베이스 변경 없음

### 🔐 보안 관련 변경

- [x] 인증/인가 로직 변경
- [x] OAuth2 설정 변경

---

## ✅ 체크리스트

### 📋 코드 품질

- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 주석과 콘솔 로그를 제거했습니다
- [x] 적절한 예외 처리를 구현했습니다
- [x] API 응답 형식이 일관성 있게 구현되었습니다 (`ApiResponse<T>` 사용)

### 🧪 테스트

- [x] 새로운 기능에 대한 단위 테스트를 작성했습니다

### 📖 문서화

- [x] 코드 주석이 적절히 작성되었습니다

### 🔧 설정 및 환경

- [x] 개발 환경에서 정상 동작을 확인했습니다
- [x] 프로덕션 환경 설정을 고려했습니다
- [x] 환경별 설정 파일이 적절히 구성되었습니다 (dev, prod)

---

## 🧪 테스트 결과

### 🔍 테스트 시나리오

1. `./gradlew test`를 실행하여 모든 테스트가 성공적으로 통과하는지 확인합니다.
2. 소셜 로그인(예: Google)을 시도합니다.
3. 로그인 성공 후, 브라우저가 리다이렉트된 URL을 확인합니다.
4. URL의 쿼리 파라미터에 `userId`가 포함되어 있지 않고, `authSuccess=true`만 있는지 확인합니다.

### 📊 테스트 커버리지

- [x] 단위 테스트 커버리지: 기존 테스트 수정 완료
- [x] 통합 테스트 완료

---

## 🚀 배포 시 주의사항

- 프론트엔드에서 로그인 성공 후 `userId`를 URL 파라미터에서 얻어오는 로직이 있었다면, 해당 로직을 수정해야 합니다. (예: `/api/v1/users/me`와 같은 API를 호출하여 사용자 정보를 가져오도록 변경)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - OAuth2 로그인 성공 후 리디렉션 URL에서 사용자 ID가 더 이상 쿼리 파라미터로 포함되지 않습니다.

- **테스트**
  - OAuth2 로그인 성공 시 예상 리디렉션 URL의 변경 사항을 반영하여 테스트가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->