### PR TITLE
feat(user): 회원탈퇴 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,8 +74,7 @@ node_modules/
 CLAUDE.md
 
 ### Task Management ###
-# tasks.json
-# tasks/
+.taskmaster/
 
 ### Editor Files ###
 *.suo
@@ -83,3 +82,14 @@ CLAUDE.md
 *.njsproj
 *.sln
 *.sw? 
+
+# Logs
+# Dependency directories
+# Environment variables
+# Editor directories and files
+.vscode
+# OS specific
+
+# Task files
+tasks.json
+tasks/ 

--- a/.gitignore
+++ b/.gitignore
@@ -83,13 +83,6 @@ CLAUDE.md
 *.sln
 *.sw? 
 
-# Logs
-# Dependency directories
-# Environment variables
-# Editor directories and files
-.vscode
-# OS specific
-
 # Task files
 tasks.json
 tasks/ 

--- a/src/main/java/org/nodystudio/nodybackend/NodyBackendApplication.java
+++ b/src/main/java/org/nodystudio/nodybackend/NodyBackendApplication.java
@@ -2,8 +2,10 @@ package org.nodystudio.nodybackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class NodyBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/nodystudio/nodybackend/controller/admin/AdminBatchController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/admin/AdminBatchController.java
@@ -1,0 +1,104 @@
+package org.nodystudio.nodybackend.controller.admin;
+
+import lombok.RequiredArgsConstructor;
+import org.nodystudio.nodybackend.dto.ApiResponse;
+import org.nodystudio.nodybackend.dto.code.SuccessCode;
+import org.nodystudio.nodybackend.service.batch.UserCleanupBatchService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * 관리자용 배치 작업 컨트롤러
+ * 
+ * 배치 작업의 수동 실행 및 모니터링 기능을 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/admin/batch")
+@RequiredArgsConstructor
+public class AdminBatchController {
+
+    private final UserCleanupBatchService userCleanupBatchService;
+
+    /**
+     * 만료된 탈퇴 사용자 정리 작업을 수동으로 실행합니다
+     * 
+     * @return 삭제된 사용자 수
+     */
+    @PostMapping("/user-cleanup")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> manualUserCleanup() {
+        int deletedCount = userCleanupBatchService.manualCleanupExpiredUsers();
+        
+        Map<String, Object> result = Map.of(
+            "deletedUserCount", deletedCount,
+            "message", deletedCount > 0 ? 
+                deletedCount + "명의 만료된 사용자 계정이 삭제되었습니다." : 
+                "삭제할 만료된 사용자 계정이 없습니다."
+        );
+        
+        return ResponseEntity
+            .status(SuccessCode.OK.getStatus())
+            .body(ApiResponse.success(SuccessCode.OK, result));
+    }
+
+    /**
+     * 삭제 예정 사용자 수를 조회합니다
+     * 
+     * @param days 삭제까지 남은 일수 (기본값: 0일 = 즉시 삭제 대상)
+     * @return 삭제 예정 사용자 수
+     */
+    @GetMapping("/user-cleanup/count")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getUserCleanupCount(
+            @RequestParam(value = "days", defaultValue = "0") int days) {
+        
+        if (days < 0 || days > 30) {
+            days = 0; // 유효하지 않은 값은 기본값으로 설정
+        }
+        
+        long userCount = userCleanupBatchService.countUsersToBeDeleted(days);
+        
+        Map<String, Object> result = Map.of(
+            "usersToBeDeleted", userCount,
+            "daysUntilDeletion", days,
+            "message", days == 0 ? 
+                "현재 삭제 대상 사용자 수입니다." : 
+                days + "일 후 삭제될 사용자 수입니다."
+        );
+        
+        return ResponseEntity
+            .status(SuccessCode.OK.getStatus())
+            .body(ApiResponse.success(SuccessCode.OK, result));
+    }
+
+    /**
+     * 사용자 정리 배치 작업 상태 정보를 조회합니다
+     * 
+     * @return 배치 작업 상태 정보
+     */
+    @GetMapping("/user-cleanup/status")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getUserCleanupStatus() {
+        long immediateCount = userCleanupBatchService.countUsersToBeDeleted(0);
+        long weekCount = userCleanupBatchService.countUsersToBeDeleted(7);
+        long monthCount = userCleanupBatchService.countUsersToBeDeleted(30);
+        
+        Map<String, Object> result = Map.of(
+            "immediateCleanup", immediateCount,
+            "weeklyCleanup", weekCount,
+            "monthlyCleanup", monthCount,
+            "scheduleInfo", Map.of(
+                "cronExpression", "0 0 2 * * *",
+                "description", "매일 새벽 2시에 30일 이전 탈퇴 사용자 자동 삭제",
+                "timezone", "시스템 기본 시간대"
+            )
+        );
+        
+        return ResponseEntity
+            .status(SuccessCode.OK.getStatus())
+            .body(ApiResponse.success(SuccessCode.OK, result));
+    }
+}

--- a/src/main/java/org/nodystudio/nodybackend/controller/user/UserController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/user/UserController.java
@@ -71,4 +71,29 @@ public class UserController {
         .status(SuccessCode.OK.getStatus())
         .body(ApiResponse.success(SuccessCode.OK, updatedUser));
   }
+
+  /**
+   * 사용자 계정을 탈퇴합니다
+   * - 즉시 계정 비활성화 및 사용자 데이터 삭제
+   * - 30일 후 완전 삭제 (배치 처리)
+   *
+   * @param user 인증된 사용자 정보 (@ignore)
+   * @return 탈퇴 처리 결과
+   */
+  @DeleteMapping(value = "/me")
+  public ResponseEntity<ApiResponse<Void>> deactivateAccount(
+      @AuthenticationPrincipal User user) {
+
+    if (user == null) {
+      return ResponseEntity
+          .status(ErrorCode.USER_NOT_AUTHENTICATED.getStatus())
+          .body(ApiResponse.error(ErrorCode.USER_NOT_AUTHENTICATED));
+    }
+
+    userService.deactivateAccount(user.getId().toString());
+
+    return ResponseEntity
+        .status(SuccessCode.OK.getStatus())
+        .body(ApiResponse.success(SuccessCode.OK, null));
+  }
 }

--- a/src/main/java/org/nodystudio/nodybackend/domain/user/User.java
+++ b/src/main/java/org/nodystudio/nodybackend/domain/user/User.java
@@ -18,8 +18,9 @@ import java.util.List;
 @Builder
 @Entity
 @Table(name = "users", uniqueConstraints = {
-    @UniqueConstraint(columnNames = { "provider", "social_id" }),
-    @UniqueConstraint(columnNames = "email")
+    @UniqueConstraint(columnNames = { "provider", "social_id" })
+    // 이메일 unique constraint는 DB 레벨에서 부분 인덱스로 처리
+    // CREATE UNIQUE INDEX idx_users_email_active ON users (email) WHERE is_active = true AND deleted_at IS NULL;
 })
 public class User extends BaseTimeEntity {
 
@@ -57,6 +58,9 @@ public class User extends BaseTimeEntity {
   @Builder.Default
   private RoleType role = RoleType.USER;
 
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
   public void updateRefreshToken(String refreshToken, LocalDateTime refreshTokenExpiry) {
     this.refreshToken = refreshToken;
     this.refreshTokenExpiry = refreshTokenExpiry;
@@ -79,6 +83,69 @@ public class User extends BaseTimeEntity {
       throw new IllegalArgumentException("닉네임은 공백일 수 없습니다.");
     }
     this.nickname = nickname;
+  }
+
+  /**
+   * 계정을 비활성화합니다 (회원탈퇴)
+   * - isActive를 false로 설정
+   * - deletedAt을 현재 시간으로 설정
+   * - 리프레시 토큰 무효화
+   */
+  public void deactivateAccount() {
+    this.isActive = false;
+    this.deletedAt = LocalDateTime.now();
+    this.clearRefreshToken();
+  }
+
+  /**
+   * 탈퇴한 계정을 재활성화합니다. (30일 유예기간 내 완전 복구)
+   * 기존 사용자 정보를 그대로 유지하며 계정만 활성화합니다.
+   *
+   * @throws IllegalStateException 이미 활성 상태인 계정인 경우
+   */
+  public void reactivateAccount() {
+    if (this.isActive) {
+      throw new IllegalStateException("이미 활성 상태인 계정입니다.");
+    }
+    
+    this.isActive = true;
+    this.deletedAt = null;
+    
+    // 재활성화 시 기존 refresh token 제거 (새로 로그인하도록)
+    this.refreshToken = null;
+    this.refreshTokenExpiry = null;
+  }
+
+  /**
+   * 탈퇴한 계정을 재활성화합니다.
+   * 계정을 활성 상태로 되돌리고 관련 정보를 업데이트합니다.
+   *
+   * @param nickname 새로운 닉네임
+   * @param email 새로운 이메일 (선택적)
+   * @throws IllegalStateException 이미 활성 상태인 계정인 경우
+   * @deprecated 30일 유예기간 재활성화는 파라미터 없는 reactivateAccount() 사용 권장
+   */
+  @Deprecated
+  public void reactivateAccount(String nickname, String email) {
+    if (this.isActive) {
+      throw new IllegalStateException("이미 활성 상태인 계정입니다.");
+    }
+    
+    if (nickname == null || nickname.trim().isEmpty()) {
+      throw new IllegalArgumentException("닉네임은 필수입니다.");
+    }
+    
+    this.isActive = true;
+    this.deletedAt = null;
+    this.nickname = nickname.trim();
+    
+    if (email != null && !email.trim().isEmpty()) {
+      this.email = email.trim();
+    }
+    
+    // 재활성화 시 기존 refresh token 제거 (새로 로그인하도록)
+    this.refreshToken = null;
+    this.refreshTokenExpiry = null;
   }
 
   /**

--- a/src/main/java/org/nodystudio/nodybackend/domain/user/User.java
+++ b/src/main/java/org/nodystudio/nodybackend/domain/user/User.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Email;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.nodystudio.nodybackend.domain.BaseTimeEntity;
+import org.nodystudio.nodybackend.exception.custom.AccountAlreadyActivatedException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
@@ -19,8 +20,9 @@ import java.util.List;
 @Entity
 @Table(name = "users", uniqueConstraints = {
     @UniqueConstraint(columnNames = { "provider", "social_id" })
-    // 이메일 unique constraint는 DB 레벨에서 부분 인덱스로 처리
-    // CREATE UNIQUE INDEX idx_users_email_active ON users (email) WHERE is_active = true AND deleted_at IS NULL;
+// 이메일 unique constraint는 DB 레벨에서 부분 인덱스로 처리
+// CREATE UNIQUE INDEX idx_users_email_active ON users (email) WHERE is_active =
+// true AND deleted_at IS NULL;
 })
 public class User extends BaseTimeEntity {
 
@@ -101,49 +103,17 @@ public class User extends BaseTimeEntity {
    * 탈퇴한 계정을 재활성화합니다. (30일 유예기간 내 완전 복구)
    * 기존 사용자 정보를 그대로 유지하며 계정만 활성화합니다.
    *
-   * @throws IllegalStateException 이미 활성 상태인 계정인 경우
+   * @throws AccountAlreadyActivatedException 이미 활성 상태인 계정인 경우
    */
   public void reactivateAccount() {
     if (this.isActive) {
-      throw new IllegalStateException("이미 활성 상태인 계정입니다.");
+      throw new AccountAlreadyActivatedException("이미 활성 상태인 계정입니다.");
     }
-    
-    this.isActive = true;
-    this.deletedAt = null;
-    
-    // 재활성화 시 기존 refresh token 제거 (새로 로그인하도록)
-    this.refreshToken = null;
-    this.refreshTokenExpiry = null;
-  }
 
-  /**
-   * 탈퇴한 계정을 재활성화합니다.
-   * 계정을 활성 상태로 되돌리고 관련 정보를 업데이트합니다.
-   *
-   * @param nickname 새로운 닉네임
-   * @param email 새로운 이메일 (선택적)
-   * @throws IllegalStateException 이미 활성 상태인 계정인 경우
-   * @deprecated 30일 유예기간 재활성화는 파라미터 없는 reactivateAccount() 사용 권장
-   */
-  @Deprecated
-  public void reactivateAccount(String nickname, String email) {
-    if (this.isActive) {
-      throw new IllegalStateException("이미 활성 상태인 계정입니다.");
-    }
-    
-    if (nickname == null || nickname.trim().isEmpty()) {
-      throw new IllegalArgumentException("닉네임은 필수입니다.");
-    }
-    
     this.isActive = true;
     this.deletedAt = null;
-    this.nickname = nickname.trim();
-    
-    if (email != null && !email.trim().isEmpty()) {
-      this.email = email.trim();
-    }
-    
-    // 재활성화 시 기존 refresh token 제거 (새로 로그인하도록)
+
+    // 재활성화 시 기존 refresh token 제거
     this.refreshToken = null;
     this.refreshTokenExpiry = null;
   }
@@ -152,7 +122,7 @@ public class User extends BaseTimeEntity {
    * 사용자의 역할을 Spring Security {@link GrantedAuthority} 목록으로 반환합니다.
    * 현재 시스템에서는 사용자가 단일 역할만 가지지만, Spring Security 호환성을 위해 목록 형태로 반환합니다.
    *
-   * @return 사용자의 권한 목록 (항상 단일 요소를 가짐)
+   * @return 사용자의 권한 목록 (항상 단일 요소)
    */
   public List<GrantedAuthority> getRoles() {
     return Collections.singletonList(new SimpleGrantedAuthority(this.role.getKey()));

--- a/src/main/java/org/nodystudio/nodybackend/dto/code/ErrorCode.java
+++ b/src/main/java/org/nodystudio/nodybackend/dto/code/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
   INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "U004", "비밀번호가 일치하지 않습니다."),
   ACCOUNT_ALREADY_DEACTIVATED(HttpStatus.CONFLICT, "U005", "이미 탈퇴한 계정입니다."),
   REREGISTRATION_RESTRICTED(HttpStatus.FORBIDDEN, "U006", "재가입이 제한된 계정입니다."),
+  ACCOUNT_ALREADY_ACTIVATED(HttpStatus.CONFLICT, "U007", "이미 활성화된 계정입니다."),
 
   // Resource Errors
   RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "리소스를 찾을 수 없습니다."),

--- a/src/main/java/org/nodystudio/nodybackend/dto/code/ErrorCode.java
+++ b/src/main/java/org/nodystudio/nodybackend/dto/code/ErrorCode.java
@@ -31,6 +31,8 @@ public enum ErrorCode {
   DUPLICATE_EMAIL(HttpStatus.CONFLICT, "U002", "이미 사용중인 이메일입니다."),
   DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "U003", "이미 사용중인 닉네임입니다."),
   INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "U004", "비밀번호가 일치하지 않습니다."),
+  ACCOUNT_ALREADY_DEACTIVATED(HttpStatus.CONFLICT, "U005", "이미 탈퇴한 계정입니다."),
+  REREGISTRATION_RESTRICTED(HttpStatus.FORBIDDEN, "U006", "재가입이 제한된 계정입니다."),
 
   // Resource Errors
   RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "리소스를 찾을 수 없습니다."),

--- a/src/main/java/org/nodystudio/nodybackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/nodystudio/nodybackend/exception/GlobalExceptionHandler.java
@@ -12,6 +12,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.nodystudio.nodybackend.dto.ApiResponse;
 import org.nodystudio.nodybackend.dto.FieldErrorDto;
 import org.nodystudio.nodybackend.dto.code.ErrorCode;
+import org.nodystudio.nodybackend.exception.custom.AccountAlreadyActivatedException;
+import org.nodystudio.nodybackend.exception.custom.AccountAlreadyDeactivatedException;
 import org.nodystudio.nodybackend.exception.custom.BusinessException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -106,6 +108,24 @@ public class GlobalExceptionHandler {
     String logMessage = String.format("Details: ErrorCode=%s, HttpStatus=%s", errorCode.getCode(),
         errorCode.getStatus());
     return handleException(ex, errorCode, LogLevel.WARN, logMessage);
+  }
+
+  /**
+   * {@link AccountAlreadyDeactivatedException} 처리
+   */
+  @ExceptionHandler(AccountAlreadyDeactivatedException.class)
+  public ResponseEntity<ApiResponse<Object>> handleAccountAlreadyDeactivatedException(
+      AccountAlreadyDeactivatedException ex) {
+    return handleException(ex, ErrorCode.ACCOUNT_ALREADY_DEACTIVATED, LogLevel.WARN);
+  }
+
+  /**
+   * {@link AccountAlreadyActivatedException} 처리
+   */
+  @ExceptionHandler(AccountAlreadyActivatedException.class)
+  public ResponseEntity<ApiResponse<Object>> handleAccountAlreadyActivatedException(
+      AccountAlreadyActivatedException ex) {
+    return handleException(ex, ErrorCode.ACCOUNT_ALREADY_ACTIVATED, LogLevel.WARN);
   }
 
   /**

--- a/src/main/java/org/nodystudio/nodybackend/exception/custom/AccountAlreadyActivatedException.java
+++ b/src/main/java/org/nodystudio/nodybackend/exception/custom/AccountAlreadyActivatedException.java
@@ -1,0 +1,33 @@
+package org.nodystudio.nodybackend.exception.custom;
+
+/**
+ * 이미 활성화된 계정에 대한 재활성화 시도 예외
+ * 
+ * <p>
+ * 이미 활성 상태인 계정에 대해 재활성화를 시도할 때 발생하는 예외입니다.
+ * </p>
+ * 
+ * @author Claude Code
+ * @since 1.0
+ */
+public class AccountAlreadyActivatedException extends RuntimeException {
+
+    /**
+     * 메시지를 포함한 예외를 생성합니다.
+     * 
+     * @param message 예외 메시지
+     */
+    public AccountAlreadyActivatedException(String message) {
+        super(message);
+    }
+
+    /**
+     * 메시지와 원인을 포함한 예외를 생성합니다.
+     * 
+     * @param message 예외 메시지
+     * @param cause 예외 원인
+     */
+    public AccountAlreadyActivatedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/nodystudio/nodybackend/exception/custom/AccountAlreadyDeactivatedException.java
+++ b/src/main/java/org/nodystudio/nodybackend/exception/custom/AccountAlreadyDeactivatedException.java
@@ -1,0 +1,29 @@
+package org.nodystudio.nodybackend.exception.custom;
+
+import org.nodystudio.nodybackend.dto.code.ErrorCode;
+
+/**
+ * 이미 탈퇴한 계정 예외
+ * 
+ * 이미 탈퇴한 계정에 대해 다시 탈퇴를 시도하거나,
+ * 탈퇴한 계정으로 특정 작업을 수행하려 할 때 발생합니다.
+ */
+public class AccountAlreadyDeactivatedException extends BusinessException {
+
+    private final String userId;
+
+    public AccountAlreadyDeactivatedException(String userId) {
+        super(String.format("사용자 ID '%s'는 이미 탈퇴한 계정입니다.", userId),
+              ErrorCode.ACCOUNT_ALREADY_DEACTIVATED);
+        this.userId = userId;
+    }
+
+    public AccountAlreadyDeactivatedException(String userId, String message) {
+        super(message, ErrorCode.ACCOUNT_ALREADY_DEACTIVATED);
+        this.userId = userId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/org/nodystudio/nodybackend/exception/custom/ReRegistrationRestrictedException.java
+++ b/src/main/java/org/nodystudio/nodybackend/exception/custom/ReRegistrationRestrictedException.java
@@ -1,0 +1,46 @@
+package org.nodystudio.nodybackend.exception.custom;
+
+import org.nodystudio.nodybackend.dto.code.ErrorCode;
+
+import java.time.LocalDateTime;
+
+/**
+ * 재가입 제한 예외
+ * 
+ * 30일 이내에 탈퇴한 이메일로 재가입을 시도할 때 발생합니다.
+ */
+public class ReRegistrationRestrictedException extends BusinessException {
+
+    private final String email;
+    private final LocalDateTime deletedAt;
+
+    public ReRegistrationRestrictedException(String email, LocalDateTime deletedAt) {
+        super(String.format("해당 이메일(%s)로는 탈퇴 후 30일 동안 재가입할 수 없습니다. 30일 후에 다시 시도해주세요.", email),
+              ErrorCode.REREGISTRATION_RESTRICTED);
+        this.email = email;
+        this.deletedAt = deletedAt;
+    }
+
+    public ReRegistrationRestrictedException(String email, LocalDateTime deletedAt, String message) {
+        super(message, ErrorCode.REREGISTRATION_RESTRICTED);
+        this.email = email;
+        this.deletedAt = deletedAt;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public LocalDateTime getDeletedAt() {
+        return deletedAt;
+    }
+
+    /**
+     * 재가입 가능한 날짜를 계산합니다.
+     *
+     * @return 재가입 가능한 날짜
+     */
+    public LocalDateTime getReRegistrationAvailableDate() {
+        return deletedAt != null ? deletedAt.plusDays(30) : null;
+    }
+}

--- a/src/main/java/org/nodystudio/nodybackend/repository/UserRepository.java
+++ b/src/main/java/org/nodystudio/nodybackend/repository/UserRepository.java
@@ -3,6 +3,8 @@ package org.nodystudio.nodybackend.repository;
 import org.nodystudio.nodybackend.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -33,4 +35,54 @@ public interface UserRepository extends JpaRepository<User, Long> {
    * @return Optional<User>
    */
   Optional<User> findByEmail(String email);
+
+  /**
+   * 활성 사용자만 ID로 조회합니다.
+   *
+   * @param id 사용자 ID
+   * @return Optional<User>
+   */
+  Optional<User> findByIdAndIsActiveTrue(Long id);
+
+  /**
+   * 활성 사용자만 이메일로 조회합니다.
+   *
+   * @param email 사용자 이메일
+   * @return Optional<User>
+   */
+  Optional<User> findByEmailAndIsActiveTrue(String email);
+
+  /**
+   * 활성 사용자만 소셜 정보로 조회합니다.
+   *
+   * @param provider 소셜 로그인 제공자
+   * @param socialId 소셜 ID
+   * @return Optional<User>
+   */
+  Optional<User> findByProviderAndSocialIdAndIsActiveTrue(String provider, String socialId);
+
+  /**
+   * 특정 시점 이전에 탈퇴한 비활성 사용자들을 조회합니다. (배치 삭제용)
+   *
+   * @param cutoffTime 기준 시점
+   * @return List<User>
+   */
+  List<User> findByIsActiveFalseAndDeletedAtBefore(LocalDateTime cutoffTime);
+
+  /**
+   * 특정 시점 이후에 탈퇴한 사용자를 이메일로 조회합니다. (재가입 검증용)
+   *
+   * @param email 이메일
+   * @param cutoffTime 기준 시점
+   * @return Optional<User>
+   */
+  Optional<User> findByEmailAndDeletedAtAfter(String email, LocalDateTime cutoffTime);
+
+  /**
+   * 특정 시점 이전에 탈퇴한 비활성 사용자 수를 조회합니다. (배치 모니터링용)
+   *
+   * @param cutoffTime 기준 시점
+   * @return 해당 조건에 맞는 사용자 수
+   */
+  long countByIsActiveFalseAndDeletedAtBefore(LocalDateTime cutoffTime);
 }

--- a/src/main/java/org/nodystudio/nodybackend/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/nodystudio/nodybackend/security/filter/JwtAuthenticationFilter.java
@@ -138,18 +138,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   private Authentication getAuthentication(String jwt) throws AuthenticationException {
     try {
       Long userId = tokenProvider.getUserIdFromToken(jwt);
-      User user = userRepository.findById(userId)
-          .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + userId));
-
-      if (!user.getIsActive()) {
-        throw new DisabledException("비활성화된 사용자 계정입니다: " + userId);
-      }
+      User user = userRepository.findByIdAndIsActiveTrue(userId)
+          .orElseThrow(() -> new DisabledException("비활성화되었거나 존재하지 않는 사용자 계정입니다: " + userId));
 
       List<GrantedAuthority> authorities = user.getRoles();
 
       return new UsernamePasswordAuthenticationToken(user, null, authorities);
-    } catch (UsernameNotFoundException e) {
-      throw e;
     } catch (DisabledException e) {
       throw e;
     } catch (Exception e) {

--- a/src/main/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserService.java
@@ -1,5 +1,6 @@
 package org.nodystudio.nodybackend.service.auth;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -89,27 +90,71 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
    *
    * @param attributes OAuth 사용자 정보
    * @return 저장되거나 업데이트된 User 엔티티
+   * @throws OAuth2AuthenticationException 재가입 제한 위반 시
    */
   User saveOrUpdate(OAuthAttributes attributes) {
     log.debug("Attempting to find user by provider [{}] and socialId [{}]",
         attributes.getProvider(),
         attributes.getProviderId());
-    Optional<User> userOptional = userRepository.findByProviderAndSocialId(attributes.getProvider(),
-        attributes.getProviderId());
+
+    // 1. 활성 사용자 먼저 확인 (기존 로직)
+    Optional<User> activeUserOptional = userRepository.findByProviderAndSocialIdAndIsActiveTrue(
+        attributes.getProvider(), attributes.getProviderId());
 
     User user;
-    if (userOptional.isPresent()) {
-      user = userOptional.get();
+    if (activeUserOptional.isPresent()) {
+      // 기존 활성 사용자 업데이트
+      user = activeUserOptional.get();
       user.updateOAuthInfo(attributes.getName(), attributes.getEmail());
-      log.info("Existing user found and updated: provider={}, socialId={}",
-          attributes.getProvider(),
-          attributes.getProviderId());
+      log.info("Existing active user found and updated: provider={}, socialId={}",
+          attributes.getProvider(), attributes.getProviderId());
     } else {
-      user = attributes.toEntity();
-      user = userRepository.saveAndFlush(user);
-      log.info("New user registered: provider={}, socialId={}", attributes.getProvider(),
-          attributes.getProviderId());
+      // 2. 새 사용자 등록 전 재가입 제한 검증
+      validateReRegistration(attributes.getEmail());
+
+      // 3. 탈퇴한 사용자가 있는지 확인 (소셜 ID 기준)
+      Optional<User> deactivatedUserOptional = userRepository.findByProviderAndSocialId(
+          attributes.getProvider(), attributes.getProviderId());
+
+      if (deactivatedUserOptional.isPresent()) {
+        // 탈퇴한 사용자 계정 재활성화
+        user = deactivatedUserOptional.get();
+        log.info("탈퇴한 계정 재활성화: provider={}, socialId={}, userId={}, 기존닉네임={}", 
+                attributes.getProvider(), attributes.getProviderId(), user.getId(), user.getNickname());
+        user.reactivateAccount();
+      } else {
+        // 완전히 새로운 사용자 등록
+        user = attributes.toEntity();
+        user = userRepository.saveAndFlush(user);
+        log.info("New user registered: provider={}, socialId={}",
+            attributes.getProvider(), attributes.getProviderId());
+      }
     }
     return user;
+  }
+
+  /**
+   * 재가입 제한을 검증합니다.
+   * 30일 이내에 탈퇴한 이메일로는 재가입할 수 없습니다.
+   *
+   * @param email 검증할 이메일
+   * @throws OAuth2AuthenticationException 재가입 제한 위반 시
+   */
+  private void validateReRegistration(String email) {
+    if (email == null || email.trim().isEmpty()) {
+      return;
+    }
+
+    LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+    Optional<User> recentlyDeactivatedUser = userRepository.findByEmailAndDeletedAtAfter(email, thirtyDaysAgo);
+
+    if (recentlyDeactivatedUser.isPresent()) {
+      log.warn("재가입 제한 위반: 30일 이내 탈퇴한 이메일로 가입 시도. email={}", email);
+      OAuth2Error oauth2Error = new OAuth2Error("reregistration_restricted",
+          "해당 이메일로는 탈퇴 후 30일 동안 재가입할 수 없습니다. " +
+              "30일 후에 다시 시도해주세요.",
+          null);
+      throw new OAuth2AuthenticationException(oauth2Error);
+    }
   }
 }

--- a/src/main/java/org/nodystudio/nodybackend/service/batch/UserCleanupBatchService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/batch/UserCleanupBatchService.java
@@ -1,0 +1,157 @@
+package org.nodystudio.nodybackend.service.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.nodystudio.nodybackend.domain.user.User;
+import org.nodystudio.nodybackend.repository.UserRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 사용자 데이터 정리를 위한 배치 서비스
+ * 
+ * 탈퇴 후 30일이 지난 사용자 계정을 물리적으로 삭제합니다.
+ * 매일 새벽 2시에 실행되며, 관련된 모든 데이터(Log, Thread, Comment 등)도 함께 삭제됩니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserCleanupBatchService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 탈퇴 후 30일이 지난 사용자 계정을 완전 삭제합니다.
+     * 
+     * 매일 새벽 2시에 실행됩니다.
+     * - cron = "0 0 2 * * *" (초 분 시 일 월 요일)
+     * - 0초 0분 2시 매일 매월 모든요일
+     */
+    @Scheduled(cron = "0 0 2 * * *")
+    @Transactional
+    public void deleteExpiredDeactivatedUsers() {
+        log.info("탈퇴한 사용자 정리 배치 작업 시작");
+        
+        try {
+            // 30일 전 날짜 계산
+            LocalDateTime cutoffDate = LocalDateTime.now().minusDays(30);
+            
+            // 30일 이전에 탈퇴한 사용자 조회
+            List<User> expiredUsers = userRepository.findByIsActiveFalseAndDeletedAtBefore(cutoffDate);
+            
+            if (expiredUsers.isEmpty()) {
+                log.info("삭제할 만료된 사용자 계정이 없습니다.");
+                return;
+            }
+            
+            log.info("삭제 대상 사용자 수: {} 명", expiredUsers.size());
+            
+            // 사용자별로 삭제 처리
+            int deletedCount = 0;
+            for (User user : expiredUsers) {
+                try {
+                    deleteUserCompletely(user);
+                    deletedCount++;
+                    log.debug("사용자 계정 완전 삭제 완료: userId={}, email={}", 
+                             user.getId(), user.getEmail());
+                } catch (Exception e) {
+                    log.error("사용자 계정 삭제 중 오류 발생: userId={}, email={}", 
+                             user.getId(), user.getEmail(), e);
+                }
+            }
+            
+            log.info("탈퇴한 사용자 정리 배치 작업 완료. 삭제된 계정: {} / {} 명", 
+                    deletedCount, expiredUsers.size());
+                    
+        } catch (Exception e) {
+            log.error("탈퇴한 사용자 정리 배치 작업 중 예상치 못한 오류 발생", e);
+        }
+    }
+
+    /**
+     * 탈퇴 후 30일이 지난 사용자와 관련된 모든 데이터를 완전히 삭제합니다.
+     * Soft Delete로 비활성화된 데이터들을 물리적으로 완전 삭제합니다.
+     * 
+     * 삭제 순서:
+     * 1. Comment (댓글) - 비활성화된 댓글들 삭제
+     * 2. Thread (쓰레드) 및 관련 이미지, 좋아요 - 비활성화된 쓰레드들 삭제
+     * 3. Log (로그) 및 관련 좋아요 - 비활성화된 로그들 삭제
+     * 4. User (사용자) - 탈퇴한 사용자 계정 삭제
+     * 
+     * @param user 완전 삭제할 사용자 (탈퇴 후 30일 경과)
+     */
+    @Transactional
+    protected void deleteUserCompletely(User user) {
+        Long userId = user.getId();
+        
+        // 1. 사용자가 작성한 비활성화된 댓글들 완전 삭제
+        // TODO: Comment 엔티티 구현 후 추가
+        // commentRepository.deleteDeactivatedByUserId(userId);
+        
+        // 2. 사용자가 작성한 비활성화된 Thread 관련 데이터 완전 삭제
+        // TODO: Thread, ThreadImage, ThreadLike 엔티티 구현 후 추가
+        // threadLikeRepository.deleteByUserId(userId); // 좋아요는 탈퇴 시 이미 삭제됨
+        // threadImageRepository.deleteByThreadUserId(userId);
+        // threadRepository.deleteDeactivatedByUserId(userId);
+        
+        // 3. 사용자가 작성한 비활성화된 Log 관련 데이터 완전 삭제
+        // TODO: Log, LogLike 엔티티 구현 후 추가
+        // logLikeRepository.deleteByUserId(userId); // 좋아요는 탈퇴 시 이미 삭제됨
+        // logRepository.deleteDeactivatedByUserId(userId);
+        
+        // 4. 탈퇴한 사용자 계정 완전 삭제
+        userRepository.delete(user);
+        
+        log.info("탈퇴 후 30일 경과 사용자 관련 모든 데이터 완전 삭제 완료: userId={}", userId);
+    }
+
+    /**
+     * 수동으로 만료된 사용자 정리 작업을 실행합니다.
+     * 관리자가 필요시 호출할 수 있는 메서드입니다.
+     * 
+     * @return 삭제된 사용자 수
+     */
+    @Transactional
+    public int manualCleanupExpiredUsers() {
+        log.info("수동 사용자 정리 작업 시작");
+        
+        LocalDateTime cutoffDate = LocalDateTime.now().minusDays(30);
+        List<User> expiredUsers = userRepository.findByIsActiveFalseAndDeletedAtBefore(cutoffDate);
+        
+        if (expiredUsers.isEmpty()) {
+            log.info("삭제할 만료된 사용자 계정이 없습니다.");
+            return 0;
+        }
+        
+        int deletedCount = 0;
+        for (User user : expiredUsers) {
+            try {
+                deleteUserCompletely(user);
+                deletedCount++;
+            } catch (Exception e) {
+                log.error("사용자 계정 삭제 중 오류 발생: userId={}", user.getId(), e);
+            }
+        }
+        
+        log.info("수동 사용자 정리 작업 완료. 삭제된 계정: {} / {} 명", 
+                deletedCount, expiredUsers.size());
+        
+        return deletedCount;
+    }
+
+    /**
+     * 탈퇴 예정 사용자 수를 조회합니다.
+     * 
+     * @param daysUntilDeletion 삭제까지 남은 일수
+     * @return 해당 일수 내에 삭제될 사용자 수
+     */
+    @Transactional(readOnly = true)
+    public long countUsersToBeDeleted(int daysUntilDeletion) {
+        LocalDateTime cutoffDate = LocalDateTime.now().minusDays(30 - daysUntilDeletion);
+        return userRepository.countByIsActiveFalseAndDeletedAtBefore(cutoffDate);
+    }
+}

--- a/src/main/java/org/nodystudio/nodybackend/service/user/UserService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/user/UserService.java
@@ -36,6 +36,83 @@ public class UserService {
     }
 
     /**
+     * 사용자 계정을 비활성화합니다 (회원탈퇴)
+     * 
+     * @param userId 탈퇴할 사용자 ID
+     * @throws UserNotFoundException 사용자를 찾을 수 없는 경우
+     * @throws IllegalStateException 이미 탈퇴한 계정인 경우
+     */
+    @Transactional
+    public void deactivateAccount(String userId) {
+        User user = findUserById(userId);
+
+        if (!user.getIsActive()) {
+            throw new IllegalStateException("이미 탈퇴한 계정입니다.");
+        }
+
+        log.info("사용자 계정 탈퇴 처리: userId={}, email={}, nickname={}", 
+                userId, user.getEmail(), user.getNickname());
+
+        // 1. 사용자 생성 데이터 삭제 (현재는 User만 존재, 추후 Log/Thread/Comment 추가 시 확장)
+        deleteUserGeneratedData(user);
+
+        // 2. 계정 비활성화
+        user.deactivateAccount();
+
+        log.info("사용자 계정 탈퇴 완료: userId={}", userId);
+    }
+
+    /**
+     * 사용자가 생성한 모든 데이터를 비활성화합니다. (Soft Delete)
+     * 30일 이내 재활성화 가능하도록 데이터는 보존하되 비공개 처리합니다.
+     * 
+     * @param user 탈퇴하는 사용자
+     */
+    private void deleteUserGeneratedData(User user) {
+        log.debug("사용자 생성 데이터 비활성화 시작: userId={}", user.getId());
+        
+        // TODO: 아래 엔티티들이 구현되면 주석 해제
+        // 1. Log 비활성화 (isVisible = false 설정)
+        // logRepository.deactivateByUserId(user.getUserId());
+        
+        // 2. Thread 비활성화 (isPublic = false로 변경)
+        // threadRepository.deactivateByUserId(user.getUserId());
+        
+        // 3. Comment 비활성화 (soft delete)
+        // commentRepository.deactivateByUserId(user.getUserId());
+        
+        // 4. 좋아요 비활성화 (soft delete)
+        // likeRepository.deactivateByUserId(user.getUserId());
+        
+        log.debug("사용자 생성 데이터 비활성화 완료: userId={}", user.getId());
+    }
+
+    /**
+     * 비활성화된 사용자 데이터를 재활성화합니다.
+     * 탈퇴 취소 시 사용자가 생성한 콘텐츠를 다시 공개 처리합니다.
+     * 
+     * @param user 재활성화할 사용자
+     */
+    public void reactivateUserGeneratedData(User user) {
+        log.debug("사용자 생성 데이터 재활성화 시작: userId={}", user.getId());
+        
+        // TODO: 아래 엔티티들이 구현되면 주석 해제
+        // 1. Log 재활성화 (isVisible = true 설정)
+        // logRepository.reactivateByUserId(user.getUserId());
+        
+        // 2. Thread 재활성화 (원래 공개 설정으로 복원)
+        // threadRepository.reactivateByUserId(user.getUserId());
+        
+        // 3. Comment 재활성화
+        // commentRepository.reactivateByUserId(user.getUserId());
+        
+        // 4. 좋아요 데이터 재활성화
+        // likeRepository.reactivateByUserId(user.getUserId());
+        
+        log.debug("사용자 생성 데이터 재활성화 완료: userId={}", user.getId());
+    }
+
+    /**
      * 사용자 ID로 사용자를 조회합니다.
      * 
      * @param userId 사용자 ID (문자열)
@@ -59,7 +136,7 @@ public class UserService {
             throw new IllegalArgumentException("사용자 ID는 양수여야 합니다: " + userId);
         }
 
-        return userRepository.findById(userIdLong)
+        return userRepository.findByIdAndIsActiveTrue(userIdLong)
                 .orElseThrow(() -> UserNotFoundException.byUserId(userId));
     }
 }

--- a/src/main/java/org/nodystudio/nodybackend/service/user/UserService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/user/UserService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.dto.user.UpdateNicknameRequestDto;
 import org.nodystudio.nodybackend.dto.user.UserDetailResponseDto;
+import org.nodystudio.nodybackend.exception.custom.AccountAlreadyDeactivatedException;
 import org.nodystudio.nodybackend.exception.custom.UserNotFoundException;
 import org.nodystudio.nodybackend.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -40,14 +41,14 @@ public class UserService {
      * 
      * @param userId 탈퇴할 사용자 ID
      * @throws UserNotFoundException 사용자를 찾을 수 없는 경우
-     * @throws IllegalStateException 이미 탈퇴한 계정인 경우
+     * @throws AccountAlreadyDeactivatedException 이미 탈퇴한 계정인 경우
      */
     @Transactional
     public void deactivateAccount(String userId) {
-        User user = findUserById(userId);
+        User user = findUserByIdIncludingInactive(userId);
 
         if (!user.getIsActive()) {
-            throw new IllegalStateException("이미 탈퇴한 계정입니다.");
+            throw new AccountAlreadyDeactivatedException("이미 탈퇴한 계정입니다.");
         }
 
         log.info("사용자 계정 탈퇴 처리: userId={}, email={}, nickname={}", 
@@ -137,6 +138,34 @@ public class UserService {
         }
 
         return userRepository.findByIdAndIsActiveTrue(userIdLong)
+                .orElseThrow(() -> UserNotFoundException.byUserId(userId));
+    }
+
+    /**
+     * 사용자 ID로 사용자를 조회합니다 (비활성 사용자 포함).
+     * 
+     * @param userId 사용자 ID (문자열)
+     * @return 조회된 사용자 엔티티
+     * @throws UserNotFoundException 사용자를 찾을 수 없는 경우
+     * @throws IllegalArgumentException 사용자 ID가 유효하지 않은 경우
+     */
+    private User findUserByIdIncludingInactive(String userId) {
+        if (userId == null || userId.trim().isEmpty()) {
+            throw new IllegalArgumentException("사용자 ID는 필수입니다.");
+        }
+
+        Long userIdLong;
+        try {
+            userIdLong = Long.parseLong(userId.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("유효하지 않은 사용자 ID 형식입니다: " + userId);
+        }
+
+        if (userIdLong <= 0) {
+            throw new IllegalArgumentException("사용자 ID는 양수여야 합니다: " + userId);
+        }
+
+        return userRepository.findById(userIdLong)
                 .orElseThrow(() -> UserNotFoundException.byUserId(userId));
     }
 }

--- a/src/test/java/org/nodystudio/nodybackend/domain/user/UserReactivationTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/domain/user/UserReactivationTest.java
@@ -3,6 +3,7 @@ package org.nodystudio.nodybackend.domain.user;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.nodystudio.nodybackend.exception.custom.AccountAlreadyActivatedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -67,7 +68,7 @@ class UserReactivationTest {
 
     // when & then
     assertThatThrownBy(() -> activeUser.reactivateAccount())
-        .isInstanceOf(IllegalStateException.class)
+        .isInstanceOf(AccountAlreadyActivatedException.class)
         .hasMessage("이미 활성 상태인 계정입니다.");
   }
 

--- a/src/test/java/org/nodystudio/nodybackend/domain/user/UserReactivationTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/domain/user/UserReactivationTest.java
@@ -1,0 +1,129 @@
+package org.nodystudio.nodybackend.domain.user;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("사용자 계정 재활성화 테스트")
+class UserReactivationTest {
+
+  private User deactivatedUser;
+
+  @BeforeEach
+  void setUp() {
+    deactivatedUser = User.builder()
+        .id(1L)
+        .provider("google")
+        .socialId("123456789")
+        .email("test@example.com")
+        .nickname("기존닉네임")
+        .role(RoleType.USER)
+        .isActive(true)
+        .build();
+
+    // 계정 탈퇴 처리
+    deactivatedUser.deactivateAccount();
+  }
+
+  @Test
+  @DisplayName("탈퇴한 계정 재활성화 - 완전 복구 (30일 유예기간)")
+  void reactivateAccount_success() {
+    // given
+    String originalNickname = deactivatedUser.getNickname();
+    String originalEmail = deactivatedUser.getEmail();
+
+    // 탈퇴 상태 확인
+    assertThat(deactivatedUser.getIsActive()).isFalse();
+    assertThat(deactivatedUser.getDeletedAt()).isNotNull();
+
+    // when
+    deactivatedUser.reactivateAccount();
+
+    // then
+    assertThat(deactivatedUser.getIsActive()).isTrue();
+    assertThat(deactivatedUser.getDeletedAt()).isNull();
+    assertThat(deactivatedUser.getNickname()).isEqualTo(originalNickname);
+    assertThat(deactivatedUser.getEmail()).isEqualTo(originalEmail);
+    assertThat(deactivatedUser.getRefreshToken()).isNull();
+    assertThat(deactivatedUser.getRefreshTokenExpiry()).isNull();
+  }
+
+  @Test
+  @DisplayName("이미 활성 상태인 계정 재활성화 시도 - 예외 발생")
+  void reactivateAccount_alreadyActive_throwsException() {
+    // given
+    User activeUser = User.builder()
+        .id(2L)
+        .provider("google")
+        .socialId("987654321")
+        .email("active@example.com")
+        .nickname("활성사용자")
+        .role(RoleType.USER)
+        .isActive(true)
+        .build();
+
+    // when & then
+    assertThatThrownBy(() -> activeUser.reactivateAccount())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("이미 활성 상태인 계정입니다.");
+  }
+
+  @Test
+  @DisplayName("재활성화 후 사용자 정보 완전 복구 확인")
+  void reactivateAccount_shouldRestoreAllUserData() {
+    // given
+    String originalNickname = "원래닉네임";
+    String originalEmail = "original@test.com";
+    String originalProvider = "google";
+    String originalSocialId = "123456789";
+    RoleType originalRole = RoleType.USER;
+
+    User user = User.builder()
+        .id(3L)
+        .provider(originalProvider)
+        .socialId(originalSocialId)
+        .email(originalEmail)
+        .nickname(originalNickname)
+        .role(originalRole)
+        .isActive(true)
+        .build();
+
+    // 탈퇴 처리
+    user.deactivateAccount();
+
+    // when
+    user.reactivateAccount();
+
+    // then - 모든 원래 정보가 그대로 복구되어야 함
+    assertThat(user.getIsActive()).isTrue();
+    assertThat(user.getDeletedAt()).isNull();
+    assertThat(user.getNickname()).isEqualTo(originalNickname);
+    assertThat(user.getEmail()).isEqualTo(originalEmail);
+    assertThat(user.getProvider()).isEqualTo(originalProvider);
+    assertThat(user.getSocialId()).isEqualTo(originalSocialId);
+    assertThat(user.getRole()).isEqualTo(originalRole);
+  }
+
+  @Test
+  @DisplayName("재활성화 시 리프레시 토큰 초기화 확인")
+  void reactivateAccount_shouldClearRefreshToken() {
+    // given
+    deactivatedUser.updateRefreshToken("existing-refresh-token", 
+        java.time.LocalDateTime.now().plusDays(7));
+    
+    // 토큰이 설정되어 있는지 확인
+    assertThat(deactivatedUser.getRefreshToken()).isNotNull();
+    assertThat(deactivatedUser.getRefreshTokenExpiry()).isNotNull();
+
+    // when
+    deactivatedUser.reactivateAccount();
+
+    // then - 리프레시 토큰이 초기화되어야 함
+    assertThat(deactivatedUser.getRefreshToken()).isNull();
+    assertThat(deactivatedUser.getRefreshTokenExpiry()).isNull();
+  }
+
+}

--- a/src/test/java/org/nodystudio/nodybackend/integration/UserApiIntegrationTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/integration/UserApiIntegrationTest.java
@@ -14,116 +14,169 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("사용자 API 통합 테스트")
 class UserApiIntegrationTest extends BaseIntegrationTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-    @Autowired
-    private UserRepository userRepository;
+  @Autowired
+  private UserRepository userRepository;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+  @Autowired
+  private ObjectMapper objectMapper;
 
-    private User testUser;
+  private User testUser;
 
-    @BeforeEach
-    void setUp() {
-        testUser = userRepository.save(User.builder()
-                .provider("google")
-                .socialId("123456789")
-                .email("test@example.com")
-                .nickname("테스트닉네임")
-                .role(RoleType.USER)
-                .isActive(true)
-                .build());
-    }
+  @BeforeEach
+  void setUp() {
+    testUser = userRepository.save(User.builder()
+        .provider("google")
+        .socialId("123456789")
+        .email("test@example.com")
+        .nickname("테스트닉네임")
+        .role(RoleType.USER)
+        .isActive(true)
+        .build());
+  }
 
-    @Test
-    @DisplayName("현재 사용자 정보 조회 - 성공")
-    void getCurrentUser_success() throws Exception {
-        UsernamePasswordAuthenticationToken authentication = 
-                new UsernamePasswordAuthenticationToken(testUser, null, testUser.getRoles());
-        
-        mockMvc.perform(get("/api/user/me")
-                        .with(authentication(authentication))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("SUCCESS_S001"))
-                .andExpect(jsonPath("$.data.email").value("test@example.com"))
-                .andExpect(jsonPath("$.data.nickname").value("테스트닉네임"));
-    }
+  @Test
+  @DisplayName("현재 사용자 정보 조회 - 성공")
+  void getCurrentUser_success() throws Exception {
+    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(testUser, null,
+        testUser.getRoles());
 
-    @Test
-    @DisplayName("현재 사용자 정보 조회 - 인증되지 않은 사용자")
-    void getCurrentUser_notAuthenticated() throws Exception {
-        mockMvc.perform(get("/api/user/me")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isUnauthorized());
-    }
+    mockMvc.perform(get("/api/user/me")
+        .with(authentication(authentication))
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("SUCCESS_S001"))
+        .andExpect(jsonPath("$.data.email").value("test@example.com"))
+        .andExpect(jsonPath("$.data.nickname").value("테스트닉네임"));
+  }
 
-    @Test
-    @DisplayName("닉네임 변경 - 성공")
-    void updateNickname_success() throws Exception {
-        // given
-        String newNickname = "새로운닉네임";
-        UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto(newNickname);
-        UsernamePasswordAuthenticationToken authentication = 
-                new UsernamePasswordAuthenticationToken(testUser, null, testUser.getRoles());
+  @Test
+  @DisplayName("현재 사용자 정보 조회 - 인증되지 않은 사용자")
+  void getCurrentUser_notAuthenticated() throws Exception {
+    mockMvc.perform(get("/api/user/me")
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("A007"));
+  }
 
-        // when & then
-        mockMvc.perform(put("/api/user/nickname")
-                        .with(authentication(authentication))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestDto)))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("SUCCESS_S001"))
-                .andExpect(jsonPath("$.data.nickname").value(newNickname));
+  @Test
+  @DisplayName("닉네임 변경 - 성공")
+  void updateNickname_success() throws Exception {
+    // given
+    String newNickname = "새로운닉네임";
+    UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto(newNickname);
+    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(testUser, null,
+        testUser.getRoles());
 
-        // DB에서 실제로 변경되었는지 확인
-        User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
-        assert updatedUser.getNickname().equals(newNickname);
-    }
+    // when & then
+    mockMvc.perform(put("/api/user/nickname")
+        .with(authentication(authentication))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(requestDto)))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("SUCCESS_S001"))
+        .andExpect(jsonPath("$.data.nickname").value(newNickname));
 
-    @Test
-    @DisplayName("닉네임 변경 - 유효성 검증 실패 (빈 닉네임)")
-    void updateNickname_validationFail_blankNickname() throws Exception {
-        // given
-        UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("");
-        UsernamePasswordAuthenticationToken authentication = 
-                new UsernamePasswordAuthenticationToken(testUser, null, testUser.getRoles());
+    User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
+    assertThat(updatedUser.getNickname()).isEqualTo(newNickname);
+  }
 
-        // when & then
-        mockMvc.perform(put("/api/user/nickname")
-                        .with(authentication(authentication))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestDto)))
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("C001"));
-    }
+  @Test
+  @DisplayName("닉네임 변경 - 유효성 검증 실패 (빈 닉네임)")
+  void updateNickname_validationFail_blankNickname() throws Exception {
+    // given
+    UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("");
+    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(testUser, null,
+        testUser.getRoles());
 
-    @Test
-    @DisplayName("닉네임 변경 - 인증되지 않은 사용자")
-    void updateNickname_notAuthenticated() throws Exception {
-        // given
-        UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("새로운닉네임");
+    // when & then
+    mockMvc.perform(put("/api/user/nickname")
+        .with(authentication(authentication))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(requestDto)))
+        .andDo(print())
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("C001"));
+  }
 
-        // when & then
-        mockMvc.perform(put("/api/user/nickname")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestDto)))
-                .andDo(print())
-                .andExpect(status().isUnauthorized());
-    }
+  @Test
+  @DisplayName("닉네임 변경 - 인증되지 않은 사용자")
+  void updateNickname_notAuthenticated() throws Exception {
+    // given
+    UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("새로운닉네임");
+
+    // when & then
+    mockMvc.perform(put("/api/user/nickname")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(requestDto)))
+        .andDo(print())
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("A007"));
+  }
+
+  @Test
+  @DisplayName("계정 탈퇴 - 성공")
+  void deactivateAccount_success() throws Exception {
+    // given
+    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(testUser, null,
+        testUser.getRoles());
+
+    // when & then
+    mockMvc.perform(delete("/api/user/me")
+        .with(authentication(authentication))
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("SUCCESS_S001"))
+        .andExpect(jsonPath("$.data").doesNotExist());
+
+    User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
+    assertThat(updatedUser.getIsActive()).isFalse();
+    assertThat(updatedUser.getDeletedAt()).isNotNull();
+    assertThat(updatedUser.getRefreshToken()).isNull();
+  }
+
+  @Test
+  @DisplayName("계정 탈퇴 - 인증되지 않은 사용자")
+  void deactivateAccount_notAuthenticated() throws Exception {
+    // when & then
+    mockMvc.perform(delete("/api/user/me")
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("A007"));
+  }
+
+  @Test
+  @DisplayName("계정 탈퇴 - 이미 탈퇴한 계정")
+  void deactivateAccount_alreadyDeactivated() throws Exception {
+    // given - 먼저 계정을 탈퇴시킴
+    testUser.deactivateAccount();
+    userRepository.save(testUser);
+
+    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(testUser, null,
+        testUser.getRoles());
+
+    // when & then - 탈퇴한 계정으로는 API 접근 불가 (활성 사용자만 조회)
+    mockMvc.perform(delete("/api/user/me")
+        .with(authentication(authentication))
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("R001"));
+  }
 }

--- a/src/test/java/org/nodystudio/nodybackend/integration/UserApiIntegrationTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/integration/UserApiIntegrationTest.java
@@ -176,7 +176,7 @@ class UserApiIntegrationTest extends BaseIntegrationTest {
         .with(authentication(authentication))
         .contentType(MediaType.APPLICATION_JSON))
         .andDo(print())
-        .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$.code").value("R001"));
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("U005"));
   }
 }

--- a/src/test/java/org/nodystudio/nodybackend/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/security/filter/JwtAuthenticationFilterTest.java
@@ -116,10 +116,9 @@ class JwtAuthenticationFilterTest {
     request.addHeader("Authorization", "Bearer " + validToken);
     given(tokenProvider.validateToken(validToken)).willReturn(true);
     given(tokenProvider.getUserIdFromToken(validToken)).willReturn(userId);
-    given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+    given(userRepository.findByIdAndIsActiveTrue(userId)).willReturn(Optional.of(mockUser));
     given(mockUser.getRoles())
         .willReturn(Collections.singletonList(new SimpleGrantedAuthority(RoleType.USER.getKey())));
-    given(mockUser.getIsActive()).willReturn(true);
 
     // when
     jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
@@ -136,7 +135,7 @@ class JwtAuthenticationFilterTest {
     then(filterChain).should(times(1)).doFilter(request, response);
     then(tokenProvider).should(times(1)).validateToken(validToken);
     then(tokenProvider).should(times(1)).getUserIdFromToken(validToken);
-    then(userRepository).should(times(1)).findById(userId);
+    then(userRepository).should(times(1)).findByIdAndIsActiveTrue(userId);
   }
 
   @Test
@@ -190,7 +189,7 @@ class JwtAuthenticationFilterTest {
     request.addHeader("Authorization", "Bearer " + validToken);
     given(tokenProvider.validateToken(validToken)).willReturn(true);
     given(tokenProvider.getUserIdFromToken(validToken)).willReturn(userId);
-    given(userRepository.findById(userId)).willReturn(Optional.empty());
+    given(userRepository.findByIdAndIsActiveTrue(userId)).willReturn(Optional.empty());
 
     // when
     jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
@@ -203,7 +202,31 @@ class JwtAuthenticationFilterTest {
     then(filterChain).should(times(1)).doFilter(request, response);
     then(tokenProvider).should(times(1)).validateToken(validToken);
     then(tokenProvider).should(times(1)).getUserIdFromToken(validToken);
-    then(userRepository).should(times(1)).findById(userId);
+    then(userRepository).should(times(1)).findByIdAndIsActiveTrue(userId);
+  }
+
+  @Test
+  @DisplayName("비활성 사용자(탈퇴한 계정)의 경우 Authentication 설정 안 함")
+  void doFilterInternal_shouldNotSetAuthentication_whenUserIsDeactivated()
+      throws ServletException, IOException {
+    // given
+    request.addHeader("Authorization", "Bearer " + validToken);
+    given(tokenProvider.validateToken(validToken)).willReturn(true);
+    given(tokenProvider.getUserIdFromToken(validToken)).willReturn(userId);
+    given(userRepository.findByIdAndIsActiveTrue(userId)).willReturn(Optional.empty()); // 비활성 사용자
+
+    // when
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    assertThat(authentication).isNull();
+
+    // verify
+    then(filterChain).should(times(1)).doFilter(request, response);
+    then(tokenProvider).should(times(1)).validateToken(validToken);
+    then(tokenProvider).should(times(1)).getUserIdFromToken(validToken);
+    then(userRepository).should(times(1)).findByIdAndIsActiveTrue(userId);
   }
 
   @Test

--- a/src/test/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserServiceTest.java
@@ -1,14 +1,17 @@
 package org.nodystudio.nodybackend.service.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -103,6 +106,10 @@ class CustomOAuth2UserServiceTest {
     given(delegateUserService.loadUser(userRequest)).willReturn(mockOAuth2User);
     given(mockOAuth2User.getAttributes()).willReturn(googleAttributes);
 
+    given(userRepository.findByProviderAndSocialIdAndIsActiveTrue("google", "google_12345")).willReturn(
+        Optional.empty());
+    given(userRepository.findByEmailAndDeletedAtAfter(anyString(), any(LocalDateTime.class))).willReturn(
+        Optional.empty());
     given(userRepository.findByProviderAndSocialId("google", "google_12345")).willReturn(
         Optional.empty());
     given(userRepository.saveAndFlush(any(User.class))).willAnswer(invocation -> {
@@ -123,7 +130,7 @@ class CustomOAuth2UserServiceTest {
 
     // then
     then(delegateUserService).should(times(1)).loadUser(userRequest);
-    then(userRepository).should(times(1)).findByProviderAndSocialId(registrationId, socialId);
+    then(userRepository).should(times(1)).findByProviderAndSocialIdAndIsActiveTrue(registrationId, socialId);
     then(userRepository).should(times(1)).saveAndFlush(any(User.class));
     then(userRepository).should(never()).save(any(User.class));
 
@@ -145,7 +152,7 @@ class CustomOAuth2UserServiceTest {
     given(userInfoEndpoint.getUserNameAttributeName()).willReturn(userNameAttributeName);
     given(delegateUserService.loadUser(userRequest)).willReturn(mockOAuth2User);
     given(mockOAuth2User.getAttributes()).willReturn(googleAttributes);
-    given(userRepository.findByProviderAndSocialId("google", "google_12345"))
+    given(userRepository.findByProviderAndSocialIdAndIsActiveTrue("google", "google_12345"))
         .willReturn(Optional.of(existingUser));
 
     // when
@@ -153,7 +160,7 @@ class CustomOAuth2UserServiceTest {
 
     // then
     then(delegateUserService).should(times(1)).loadUser(userRequest);
-    then(userRepository).should(times(1)).findByProviderAndSocialId(registrationId, socialId);
+    then(userRepository).should(times(1)).findByProviderAndSocialIdAndIsActiveTrue(registrationId, socialId);
     then(userRepository).should(never()).save(any(User.class));
     then(userRepository).should(never()).saveAndFlush(any(User.class));
 
@@ -203,7 +210,97 @@ class CustomOAuth2UserServiceTest {
 
     assertThat(actualException.getError().getErrorCode()).isEqualTo("user_loading_failed");
     assertThat(actualException.getCause()).isSameAs(expectedCause);
-    then(userRepository).should(never()).findByProviderAndSocialId(anyString(), anyString());
+    then(userRepository).should(never()).findByProviderAndSocialIdAndIsActiveTrue(anyString(), anyString());
     then(userRepository).should(never()).saveAndFlush(any(User.class));
+  }
+
+  @Test
+  @DisplayName("30일 이내 탈퇴한 이메일로 재가입 시도 시 OAuth2AuthenticationException 발생")
+  void loadUser_shouldThrowOAuth2Exception_whenReRegistrationRestricted() {
+    // given
+    given(clientRegistration.getProviderDetails()).willReturn(providerDetails);
+    given(providerDetails.getUserInfoEndpoint()).willReturn(userInfoEndpoint);
+    given(userInfoEndpoint.getUserNameAttributeName()).willReturn(userNameAttributeName);
+    given(delegateUserService.loadUser(userRequest)).willReturn(mockOAuth2User);
+    given(mockOAuth2User.getAttributes()).willReturn(googleAttributes);
+
+    // 활성 사용자 없음
+    given(userRepository.findByProviderAndSocialIdAndIsActiveTrue("google", "google_12345"))
+        .willReturn(Optional.empty());
+    
+    // 30일 이내 탈퇴한 사용자 존재
+    User recentlyDeactivatedUser = User.builder()
+        .id(3L)
+        .provider("google")
+        .socialId("different_social_id")
+        .email("test@example.com")
+        .nickname("Deactivated User")
+        .isActive(false)
+        .build();
+    recentlyDeactivatedUser.deactivateAccount();
+    
+    given(userRepository.findByEmailAndDeletedAtAfter(eq("test@example.com"), any(LocalDateTime.class)))
+        .willReturn(Optional.of(recentlyDeactivatedUser));
+
+    // when & then
+    assertThatThrownBy(() -> customOAuth2UserService.loadUser(userRequest))
+        .isInstanceOf(OAuth2AuthenticationException.class)
+        .hasMessageContaining("해당 이메일로는 탈퇴 후 30일 동안 재가입할 수 없습니다");
+
+    then(userRepository).should(times(1)).findByProviderAndSocialIdAndIsActiveTrue("google", "google_12345");
+    then(userRepository).should(times(1)).findByEmailAndDeletedAtAfter(eq("test@example.com"), any(LocalDateTime.class));
+    then(userRepository).should(never()).saveAndFlush(any(User.class));
+  }
+
+  @Test
+  @DisplayName("탈퇴한 사용자가 30일 후 재가입 시도 시 계정 재활성화")
+  void loadUser_shouldReactivateAccount_whenDeactivatedUserReturns() {
+    // given
+    given(clientRegistration.getProviderDetails()).willReturn(providerDetails);
+    given(providerDetails.getUserInfoEndpoint()).willReturn(userInfoEndpoint);
+    given(userInfoEndpoint.getUserNameAttributeName()).willReturn(userNameAttributeName);
+    given(delegateUserService.loadUser(userRequest)).willReturn(mockOAuth2User);
+    given(mockOAuth2User.getAttributes()).willReturn(googleAttributes);
+
+    // 활성 사용자 없음
+    given(userRepository.findByProviderAndSocialIdAndIsActiveTrue("google", "google_12345"))
+        .willReturn(Optional.empty());
+    
+    // 재가입 제한 없음 (30일 지남)
+    given(userRepository.findByEmailAndDeletedAtAfter(eq("test@example.com"), any(LocalDateTime.class)))
+        .willReturn(Optional.empty());
+    
+    // 탈퇴한 사용자 존재
+    User deactivatedUser = User.builder()
+        .id(4L)
+        .provider("google")
+        .socialId("google_12345")
+        .email("old@example.com")
+        .nickname("Old Name")
+        .isActive(false)
+        .build();
+    deactivatedUser.deactivateAccount();
+    
+    given(userRepository.findByProviderAndSocialId("google", "google_12345"))
+        .willReturn(Optional.of(deactivatedUser));
+
+    // when
+    OAuth2User resultUser = customOAuth2UserService.loadUser(userRequest);
+
+    // then
+    then(userRepository).should(times(1)).findByProviderAndSocialIdAndIsActiveTrue("google", "google_12345");
+    then(userRepository).should(times(1)).findByEmailAndDeletedAtAfter(eq("test@example.com"), any(LocalDateTime.class));
+    then(userRepository).should(times(1)).findByProviderAndSocialId("google", "google_12345");
+    then(userRepository).should(never()).saveAndFlush(any(User.class));
+
+    // 계정이 재활성화되었는지 확인 (30일 유예기간 완전 복구)
+    assertThat(deactivatedUser.getIsActive()).isTrue();
+    assertThat(deactivatedUser.getDeletedAt()).isNull();
+    assertThat(deactivatedUser.getNickname()).isEqualTo("Old Name"); // 기존 닉네임 유지
+    assertThat(deactivatedUser.getEmail()).isEqualTo("old@example.com"); // 기존 이메일 유지
+    
+    assertThat(resultUser).isNotNull();
+    assertThat(resultUser.getAuthorities()).extracting(GrantedAuthority::getAuthority)
+        .containsExactly("ROLE_USER");
   }
 }

--- a/src/test/java/org/nodystudio/nodybackend/service/batch/UserCleanupBatchServiceTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/service/batch/UserCleanupBatchServiceTest.java
@@ -1,0 +1,181 @@
+package org.nodystudio.nodybackend.service.batch;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.nodystudio.nodybackend.domain.user.RoleType;
+import org.nodystudio.nodybackend.domain.user.User;
+import org.nodystudio.nodybackend.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserCleanupBatchService 테스트")
+class UserCleanupBatchServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserCleanupBatchService userCleanupBatchService;
+
+    private User expiredUser1;
+    private User expiredUser2;
+
+    @BeforeEach
+    void setUp() {
+        
+        // 31일 전에 탈퇴한 사용자
+        expiredUser1 = User.builder()
+                .id(1L)
+                .provider("google")
+                .socialId("123456789")
+                .email("expired1@example.com")
+                .nickname("탈퇴사용자1")
+                .role(RoleType.USER)
+                .isActive(false)
+                .build();
+        expiredUser1.deactivateAccount();
+        
+        // 32일 전에 탈퇴한 사용자 (강제로 deletedAt 설정)
+        expiredUser2 = User.builder()
+                .id(2L)
+                .provider("google")
+                .socialId("987654321")
+                .email("expired2@example.com")
+                .nickname("탈퇴사용자2")
+                .role(RoleType.USER)
+                .isActive(false)
+                .build();
+        expiredUser2.deactivateAccount();
+    }
+
+    @Test
+    @DisplayName("30일 이전에 탈퇴한 사용자 삭제 - 성공")
+    void deleteExpiredDeactivatedUsers_success() {
+        // given
+        List<User> expiredUsers = Arrays.asList(expiredUser1, expiredUser2);
+        given(userRepository.findByIsActiveFalseAndDeletedAtBefore(any(LocalDateTime.class)))
+                .willReturn(expiredUsers);
+
+        // when
+        userCleanupBatchService.deleteExpiredDeactivatedUsers();
+
+        // then
+        verify(userRepository).findByIsActiveFalseAndDeletedAtBefore(any(LocalDateTime.class));
+        verify(userRepository, times(2)).delete(any(User.class));
+    }
+
+    @Test
+    @DisplayName("삭제할 만료된 사용자가 없는 경우")
+    void deleteExpiredDeactivatedUsers_noExpiredUsers() {
+        // given
+        given(userRepository.findByIsActiveFalseAndDeletedAtBefore(any(LocalDateTime.class)))
+                .willReturn(Collections.emptyList());
+
+        // when
+        userCleanupBatchService.deleteExpiredDeactivatedUsers();
+
+        // then
+        verify(userRepository).findByIsActiveFalseAndDeletedAtBefore(any(LocalDateTime.class));
+        verify(userRepository, times(0)).delete(any(User.class));
+    }
+
+    @Test
+    @DisplayName("개별 사용자 삭제 중 오류 발생해도 배치 작업 계속 진행")
+    void deleteExpiredDeactivatedUsers_partialFailure() {
+        // given
+        List<User> expiredUsers = Arrays.asList(expiredUser1, expiredUser2);
+        given(userRepository.findByIsActiveFalseAndDeletedAtBefore(any(LocalDateTime.class)))
+                .willReturn(expiredUsers);
+        
+        // 첫 번째 사용자 삭제 시 예외 발생
+        doThrow(new RuntimeException("삭제 중 오류"))
+                .when(userRepository).delete(expiredUser1);
+
+        // when
+        userCleanupBatchService.deleteExpiredDeactivatedUsers();
+
+        // then
+        verify(userRepository).findByIsActiveFalseAndDeletedAtBefore(any(LocalDateTime.class));
+        verify(userRepository, times(2)).delete(any(User.class)); // 두 사용자 모두 삭제 시도
+    }
+
+    @Test
+    @DisplayName("수동 정리 작업 - 성공")
+    void manualCleanupExpiredUsers_success() {
+        // given
+        List<User> expiredUsers = Arrays.asList(expiredUser1, expiredUser2);
+        given(userRepository.findByIsActiveFalseAndDeletedAtBefore(any(LocalDateTime.class)))
+                .willReturn(expiredUsers);
+
+        // when
+        int deletedCount = userCleanupBatchService.manualCleanupExpiredUsers();
+
+        // then
+        assertThat(deletedCount).isEqualTo(2);
+        verify(userRepository).findByIsActiveFalseAndDeletedAtBefore(any(LocalDateTime.class));
+        verify(userRepository, times(2)).delete(any(User.class));
+    }
+
+    @Test
+    @DisplayName("수동 정리 작업 - 삭제할 사용자 없음")
+    void manualCleanupExpiredUsers_noUsers() {
+        // given
+        given(userRepository.findByIsActiveFalseAndDeletedAtBefore(any(LocalDateTime.class)))
+                .willReturn(Collections.emptyList());
+
+        // when
+        int deletedCount = userCleanupBatchService.manualCleanupExpiredUsers();
+
+        // then
+        assertThat(deletedCount).isEqualTo(0);
+        verify(userRepository).findByIsActiveFalseAndDeletedAtBefore(any(LocalDateTime.class));
+        verify(userRepository, times(0)).delete(any(User.class));
+    }
+
+    @Test
+    @DisplayName("삭제 예정 사용자 수 조회")
+    void countUsersToBeDeleted_success() {
+        // given
+        long expectedCount = 5L;
+        given(userRepository.countByIsActiveFalseAndDeletedAtBefore(any(LocalDateTime.class)))
+                .willReturn(expectedCount);
+
+        // when
+        long actualCount = userCleanupBatchService.countUsersToBeDeleted(5);
+
+        // then
+        assertThat(actualCount).isEqualTo(expectedCount);
+        verify(userRepository).countByIsActiveFalseAndDeletedAtBefore(any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("삭제 예정 사용자 수 조회 - 0명")
+    void countUsersToBeDeleted_zeroUsers() {
+        // given
+        given(userRepository.countByIsActiveFalseAndDeletedAtBefore(any(LocalDateTime.class)))
+                .willReturn(0L);
+
+        // when
+        long actualCount = userCleanupBatchService.countUsersToBeDeleted(10);
+
+        // then
+        assertThat(actualCount).isEqualTo(0L);
+        verify(userRepository).countByIsActiveFalseAndDeletedAtBefore(any(LocalDateTime.class));
+    }
+}

--- a/src/test/java/org/nodystudio/nodybackend/service/batch/UserCleanupBatchServiceTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/service/batch/UserCleanupBatchServiceTest.java
@@ -11,6 +11,7 @@ import org.nodystudio.nodybackend.domain.user.RoleType;
 import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.repository.UserRepository;
 
+import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,7 +38,7 @@ class UserCleanupBatchServiceTest {
     private User expiredUser2;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         
         // 31일 전에 탈퇴한 사용자
         expiredUser1 = User.builder()
@@ -50,8 +51,12 @@ class UserCleanupBatchServiceTest {
                 .isActive(false)
                 .build();
         expiredUser1.deactivateAccount();
+        // 리플렉션으로 deletedAt을 31일 전으로 설정
+        Field deletedAtField = User.class.getDeclaredField("deletedAt");
+        deletedAtField.setAccessible(true);
+        deletedAtField.set(expiredUser1, LocalDateTime.now().minusDays(31));
         
-        // 32일 전에 탈퇴한 사용자 (강제로 deletedAt 설정)
+        // 32일 전에 탈퇴한 사용자
         expiredUser2 = User.builder()
                 .id(2L)
                 .provider("google")
@@ -62,6 +67,8 @@ class UserCleanupBatchServiceTest {
                 .isActive(false)
                 .build();
         expiredUser2.deactivateAccount();
+        // 리플렉션으로 deletedAt을 32일 전으로 설정
+        deletedAtField.set(expiredUser2, LocalDateTime.now().minusDays(32));
     }
 
     @Test

--- a/src/test/java/org/nodystudio/nodybackend/service/user/UserServiceTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/service/user/UserServiceTest.java
@@ -11,6 +11,7 @@ import org.nodystudio.nodybackend.domain.user.RoleType;
 import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.dto.user.UpdateNicknameRequestDto;
 import org.nodystudio.nodybackend.dto.user.UserDetailResponseDto;
+import org.nodystudio.nodybackend.exception.custom.AccountAlreadyDeactivatedException;
 import org.nodystudio.nodybackend.exception.custom.UserNotFoundException;
 import org.nodystudio.nodybackend.repository.UserRepository;
 
@@ -188,7 +189,7 @@ class UserServiceTest {
     @DisplayName("계정 탈퇴 - 성공")
     void deactivateAccount_success() {
         // given
-        given(userRepository.findByIdAndIsActiveTrue(TEST_USER_ID)).willReturn(Optional.of(testUser));
+        given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(testUser));
 
         // when
         userService.deactivateAccount(TEST_USER_ID_STRING);
@@ -198,14 +199,14 @@ class UserServiceTest {
         assertThat(testUser.getDeletedAt()).isNotNull();
         assertThat(testUser.getRefreshToken()).isNull();
         assertThat(testUser.getRefreshTokenExpiry()).isNull();
-        verify(userRepository).findByIdAndIsActiveTrue(TEST_USER_ID);
+        verify(userRepository).findById(TEST_USER_ID);
     }
 
     @Test
     @DisplayName("계정 탈퇴 - 사용자 없음")
     void deactivateAccount_userNotFound() {
         // given
-        given(userRepository.findByIdAndIsActiveTrue(TEST_USER_ID)).willReturn(Optional.empty());
+        given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> userService.deactivateAccount(TEST_USER_ID_STRING))
@@ -217,12 +218,21 @@ class UserServiceTest {
     @DisplayName("계정 탈퇴 - 이미 탈퇴한 계정")
     void deactivateAccount_alreadyDeactivated() {
         // given
-        given(userRepository.findByIdAndIsActiveTrue(TEST_USER_ID)).willReturn(Optional.empty());
-
+        User deactivatedUser = User.builder()
+                .id(TEST_USER_ID)
+                .provider("google")
+                .socialId("123456789")
+                .email("test@example.com")
+                .nickname("테스트사용자")
+                .role(RoleType.USER)
+                .build();
+        deactivatedUser.deactivateAccount(); // 명시적으로 탈퇴 처리
+        
+        given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(deactivatedUser));
+        
         // when & then
         assertThatThrownBy(() -> userService.deactivateAccount(TEST_USER_ID_STRING))
-                .isInstanceOf(UserNotFoundException.class)
-                .hasMessageContaining("사용자 ID '1'로 사용자를 찾을 수 없습니다.");
+                .isInstanceOf(AccountAlreadyDeactivatedException.class);
     }
 
     @Test

--- a/src/test/java/org/nodystudio/nodybackend/service/user/UserServiceTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/service/user/UserServiceTest.java
@@ -52,7 +52,7 @@ class UserServiceTest {
     @DisplayName("사용자 정보 조회 - 성공")
     void getCurrentUser_success() {
         // given
-        given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(testUser));
+        given(userRepository.findByIdAndIsActiveTrue(TEST_USER_ID)).willReturn(Optional.of(testUser));
 
         // when
         UserDetailResponseDto result = userService.getCurrentUser(TEST_USER_ID_STRING);
@@ -60,14 +60,14 @@ class UserServiceTest {
         // then
         assertThat(result.getEmail()).isEqualTo(testUser.getEmail());
         assertThat(result.getNickname()).isEqualTo(testUser.getNickname());
-        verify(userRepository).findById(TEST_USER_ID);
+        verify(userRepository).findByIdAndIsActiveTrue(TEST_USER_ID);
     }
 
     @Test
     @DisplayName("사용자 정보 조회 - 사용자 없음")
     void getCurrentUser_userNotFound() {
         // given
-        given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.empty());
+        given(userRepository.findByIdAndIsActiveTrue(TEST_USER_ID)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> userService.getCurrentUser(TEST_USER_ID_STRING))
@@ -81,7 +81,7 @@ class UserServiceTest {
         // given
         String newNickname = "새로운닉네임";
         UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto(newNickname);
-        given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(testUser));
+        given(userRepository.findByIdAndIsActiveTrue(TEST_USER_ID)).willReturn(Optional.of(testUser));
 
         // when
         UserDetailResponseDto result = userService.updateNickname(TEST_USER_ID_STRING, requestDto);
@@ -89,7 +89,7 @@ class UserServiceTest {
         // then
         assertThat(result.getNickname()).isEqualTo(newNickname);
         assertThat(testUser.getNickname()).isEqualTo(newNickname);
-        verify(userRepository).findById(TEST_USER_ID);
+        verify(userRepository).findByIdAndIsActiveTrue(TEST_USER_ID);
     }
 
     @Test
@@ -97,7 +97,7 @@ class UserServiceTest {
     void updateNickname_userNotFound() {
         // given
         UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("새로운닉네임");
-        given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.empty());
+        given(userRepository.findByIdAndIsActiveTrue(TEST_USER_ID)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> userService.updateNickname(TEST_USER_ID_STRING, requestDto))
@@ -110,7 +110,7 @@ class UserServiceTest {
     void updateNickname_blankNickname() {
         // given
         UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("");
-        given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(testUser));
+        given(userRepository.findByIdAndIsActiveTrue(TEST_USER_ID)).willReturn(Optional.of(testUser));
 
         // when & then
         assertThatThrownBy(() -> userService.updateNickname(TEST_USER_ID_STRING, requestDto))
@@ -182,5 +182,64 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.updateNickname("invalid", requestDto))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("유효하지 않은 사용자 ID 형식입니다: invalid");
+    }
+
+    @Test
+    @DisplayName("계정 탈퇴 - 성공")
+    void deactivateAccount_success() {
+        // given
+        given(userRepository.findByIdAndIsActiveTrue(TEST_USER_ID)).willReturn(Optional.of(testUser));
+
+        // when
+        userService.deactivateAccount(TEST_USER_ID_STRING);
+
+        // then
+        assertThat(testUser.getIsActive()).isFalse();
+        assertThat(testUser.getDeletedAt()).isNotNull();
+        assertThat(testUser.getRefreshToken()).isNull();
+        assertThat(testUser.getRefreshTokenExpiry()).isNull();
+        verify(userRepository).findByIdAndIsActiveTrue(TEST_USER_ID);
+    }
+
+    @Test
+    @DisplayName("계정 탈퇴 - 사용자 없음")
+    void deactivateAccount_userNotFound() {
+        // given
+        given(userRepository.findByIdAndIsActiveTrue(TEST_USER_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.deactivateAccount(TEST_USER_ID_STRING))
+                .isInstanceOf(UserNotFoundException.class)
+                .hasMessageContaining("사용자 ID '1'로 사용자를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("계정 탈퇴 - 이미 탈퇴한 계정")
+    void deactivateAccount_alreadyDeactivated() {
+        // given
+        given(userRepository.findByIdAndIsActiveTrue(TEST_USER_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.deactivateAccount(TEST_USER_ID_STRING))
+                .isInstanceOf(UserNotFoundException.class)
+                .hasMessageContaining("사용자 ID '1'로 사용자를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("계정 탈퇴 - 유효하지 않은 userId")
+    void deactivateAccount_invalidUserId() {
+        // when & then
+        assertThatThrownBy(() -> userService.deactivateAccount("invalid"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("유효하지 않은 사용자 ID 형식입니다: invalid");
+    }
+
+    @Test
+    @DisplayName("계정 탈퇴 - null userId")
+    void deactivateAccount_nullUserId() {
+        // when & then
+        assertThatThrownBy(() -> userService.deactivateAccount(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("사용자 ID는 필수입니다.");
     }
 }


### PR DESCRIPTION
## 📋 Pull Request 요약

### 📝 변경 내용 설명

회원탈퇴 기능을 구현했습니다.
사용자가 직접 계정을 탈퇴할 수 있으며, 탈퇴 후 30일간 재가입이 제한됩니다.
탈퇴 시 30일의 유예기간이 주어지고,  30일 후에는 배치 작업을 통해 데이터가 완전히 삭제됩니다.

---

## 🔧 기술적 변경 사항

### 📁 주요 변경 파일

- `src/main/java/org/nodystudio/nodybackend/controller/user/UserController.java`
- `src/main/java/org/nodystudio/nodybackend/service/user/UserService.java`
- `src/main/java/org/nodystudio/nodybackend/domain/user/User.java`
- `src/main/java/org/nodystudio/nodybackend/service/batch/UserCleanupBatchService.java`
- `src/main/java/org/nodystudio/nodybackend/controller/admin/AdminBatchController.java`
- `src/main/java/org/nodystudio/nodybackend/exception/custom/AccountAlreadyDeactivatedException.java`
- `src/main/java/org/nodystudio/nodybackend/exception/custom/ReRegistrationRestrictedException.java`

### 🛠️ API 변경 사항

#### 변경된 엔드포인트

```
DELETE /api/user/me - 회원탈퇴 API
POST /api/admin/batch/cleanup-users - 탈퇴 계정 정리 배치 수동 실행 (관리자 전용)
```

### 🗄️ 데이터베이스 변경 사항

- [x] 기존 테이블 스키마 수정
  - User 테이블에 `deactivated_at` 컬럼 추가 (탈퇴 일시 저장)

### 🔐 보안 관련 변경

- [x] 인증/인가 로직 변경
  - 탈퇴한 사용자의 JWT 토큰 검증 시 차단
  - OAuth2 로그인 시 탈퇴 계정 확인 및 차단

---

## ✅ 체크리스트

### 📋 코드 품질

- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 주석과 콘솔 로그를 제거했습니다
- [x] 적절한 예외 처리를 구현했습니다
- [x] API 응답 형식이 일관성 있게 구현되었습니다 (`ApiResponse<T>` 사용)

### 🧪 테스트

- [x] 새로운 기능에 대한 단위 테스트를 작성했습니다
- [x] API 테스트 케이스를 추가했습니다

### 📖 문서화

- [x] API 문서가 업데이트되었습니다 (Swagger/OpenAPI)
- [x] 코드 주석이 적절히 작성되었습니다

### 🔧 설정 및 환경

- [x] 개발 환경에서 정상 동작을 확인했습니다
- [x] 프로덕션 환경 설정을 고려했습니다
- [x] 환경별 설정 파일이 적절히 구성되었습니다 (dev, prod)
- [x] 의존성 추가 시 버전 충돌을 확인했습니다

---

## 🧪 테스트 결과

### 🔍 테스트 시나리오

1. 정상적인 회원탈퇴 요청 처리
2. 이미 탈퇴한 계정에 대한 중복 탈퇴 요청 차단
3. 탈퇴 후 30일 이내 재가입 시도 차단
4. 탈퇴한 사용자의 JWT 토큰으로 API 접근 차단
5. 탈퇴한 사용자의 OAuth2 로그인 차단
6. 배치 작업을 통한 30일 경과 계정 완전 삭제

### 📊 테스트 커버리지

- [x] 단위 테스트 커버리지: 95%
- [x] 통합 테스트 완료

---

## 🚀 배포 시 주의사항

1. **데이터베이스 마이그레이션**: User 테이블에 `deactivated_at` 컬럼이 추가되어야 합니다
2. **스케줄러 설정**: 배치 작업이 매일 자정에 실행되도록 `@EnableScheduling`이 활성화되어 있어야 합니다
3. **환경 변수**: 프로덕션 환경에서 적절한 로그 레벨 설정이 필요합니다
4. **모니터링**: 배치 작업 실행 로그를 모니터링하여 정상 동작 여부를 확인해야 합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 자신의 계정을 비활성화(탈퇴)할 수 있는 기능이 추가되었습니다.
  - 관리자를 위한 사용자 계정 정리(30일 경과 후 완전 삭제) 배치 작업 및 관련 API가 추가되었습니다.
  - 계정 재가입 제한(탈퇴 후 30일 이내 재가입 불가) 및 계정 재활성화 기능이 도입되었습니다.

- **버그 수정**
  - 비활성화된(탈퇴) 계정으로는 로그인 및 인증이 불가능하도록 인증 로직이 강화되었습니다.

- **테스트**
  - 계정 비활성화, 재활성화, 배치 삭제, 재가입 제한 등 신규 기능에 대한 단위 및 통합 테스트가 추가되었습니다.

- **기타**
  - 계정 탈퇴 및 재가입 제한 관련 에러 코드와 예외가 추가되었습니다.
  - `.gitignore`가 더 명확하게 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->