### PR TITLE
hotfix: SecurityConfig OAuth2 로그인 경로 매처 수정

### DIFF
--- a/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
+++ b/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
@@ -101,7 +101,7 @@ public class SecurityConfig {
                 userInfo -> userInfo.userService(customOAuth2UserService))
             .successHandler(oAuth2LoginSuccessHandler))
         .authorizeHttpRequests(authorize -> authorize
-            .requestMatchers("/api/auth/**", "/api/public/**", "/oauth2/**", "/login/oauth2/**")
+            .requestMatchers("/api/auth/**", "/api/public/**", "/oauth2/**", "/login/**")
             .permitAll()
             .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
             .requestMatchers("/openapi.json", "/favicon.ico").permitAll()
@@ -133,7 +133,7 @@ public class SecurityConfig {
                 userInfo -> userInfo.userService(customOAuth2UserService))
             .successHandler(oAuth2LoginSuccessHandler))
         .authorizeHttpRequests(authorize -> authorize
-            .requestMatchers("/api/auth/**", "/api/public/**", "/oauth2/**", "/login/oauth2/**")
+            .requestMatchers("/api/auth/**", "/api/public/**", "/oauth2/**", "/login/**")
             .permitAll()
             .requestMatchers("/api/admin/**").hasRole("ADMIN")
             .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/favicon.ico").permitAll()


### PR DESCRIPTION
## 📋 Pull Request 요약

### 📝 변경 내용 설명

`/login/oauth2/**`에서 `/login/**`로 변경하여 OAuth2 로그인 시 경로 매칭 문제를 해결합니다.

---

## 🔧 기술적 변경 사항

### 📁 주요 변경 파일

- `src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java`

### 🛠️ API 변경 사항

#### 변경된 엔드포인트

OAuth2 로그인 경로 매처 변경:
- **Before**: `/login/oauth2/**`
- **After**: `/login/**`

이 변경으로 다음 경로들이 모두 허용됩니다:
- `/login/oauth2/code/google`
- `/login/oauth2/code/kakao`
- `/login/oauth2/code/naver`
- 기타 `/login/` 하위 모든 경로

### 🗄️ 데이터베이스 변경 사항

- [x] 데이터베이스 변경 없음

### 🔐 보안 관련 변경

- [x] OAuth2 설정 변경
- [x] 인증/인가 로직 변경 (경로 매처 수정)

---

## ✅ 체크리스트

### 📋 코드 품질

- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 주석과 콘솔 로그를 제거했습니다
- [x] 적절한 예외 처리를 구현했습니다
- [x] API 응답 형식이 일관성 있게 구현되었습니다 (`ApiResponse<T>` 사용)

### 🧪 테스트

- [ ] 새로운 기능에 대한 단위 테스트를 작성했습니다 (기존 기능 수정으로 해당 없음)
- [ ] API 테스트 케이스를 추가했습니다 (기존 테스트로 충분)

### 📖 문서화

- [x] API 문서가 업데이트되었습니다 (OAuth2 경로는 문서화된 API가 아님)
- [x] 코드 주석이 적절히 작성되었습니다
- [x] 변경 사항에 대한 문서를 작성했습니다

### 🔧 설정 및 환경

- [x] 개발 환경에서 정상 동작을 확인했습니다
- [x] 프로덕션 환경 설정을 고려했습니다
- [x] 환경별 설정 파일이 적절히 구성되었습니다 (dev, prod)
- [x] 의존성 추가 시 버전 충돌을 확인했습니다 (의존성 변경 없음)

---

## 🧪 테스트 결과

### 🔍 테스트 시나리오

1. **Google OAuth2 로그인 테스트**
   - `/login/oauth2/code/google` 경로로 리다이렉트 확인

### 📊 테스트 커버리지

- [x] 단위 테스트 커버리지: 기존 테스트 유지
- [x] 통합 테스트 완료

---

## 📸 스크린샷 / 로그

SecurityConfig 변경 내용:

```diff
// dev 환경
.authorizeHttpRequests(authorize -> authorize
-   .requestMatchers("/api/auth/**", "/api/public/**", "/oauth2/**", "/login/oauth2/**")
+   .requestMatchers("/api/auth/**", "/api/public/**", "/oauth2/**", "/login/**")
    .permitAll()

// prod 환경  
.authorizeHttpRequests(authorize -> authorize
-   .requestMatchers("/api/auth/**", "/api/public/**", "/oauth2/**", "/login/oauth2/**")
+   .requestMatchers("/api/auth/**", "/api/public/**", "/oauth2/**", "/login/**")
    .permitAll()
```

---

## 🚀 배포 시 주의사항

이 변경사항은 OAuth2 로그인 플로우에 영향을 주므로:

1. **배포 후 즉시 OAuth2 로그인 테스트 필요**
   - Google, Kakao, Naver 각 소셜 로그인 확인
   
2. **사용자 인증 세션에는 영향 없음**
   - 기존 로그인된 사용자의 JWT 토큰은 영향받지 않음
   
3. **롤백 준비**
   - 문제 발생 시 빠른 롤백을 위해 이전 버전 준비

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 로그인 관련 요청 경로 허용 범위가 확장되어, 이제 "/login/" 하위의 모든 경로에서 접근이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->