### PR TITLE
feat(docs): Smart Doc에서 OpenAPI 3.0 (Swagger)로 API 문서화 마이그레이션

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build and Test with Gradle
         env:
           SPRING_PROFILES_ACTIVE: test
-        run: ./gradlew smartDocOpenAPI build --no-daemon
+        run: ./gradlew build --no-daemon
 
       - name: Upload JAR Artifact
         uses: actions/upload-artifact@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     java
     id("org.springframework.boot") version "3.4.5"
     id("io.spring.dependency-management") version "1.1.7"
-    id("com.ly.smart-doc") version "3.1.0"
     jacoco
 }
 
@@ -50,9 +49,6 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
 }
 
-smartdoc {
-    configFile =  file("src/main/resources/smart-doc.json")
-}
 
 tasks.withType<Test> {
     useJUnitPlatform()

--- a/src/main/java/org/nodystudio/nodybackend/config/OpenApiConfig.java
+++ b/src/main/java/org/nodystudio/nodybackend/config/OpenApiConfig.java
@@ -1,0 +1,46 @@
+package org.nodystudio.nodybackend.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * OpenAPI 3.0 설정을 위한 Configuration 클래스
+ */
+@Configuration
+public class OpenApiConfig {
+
+  /**
+   * OpenAPI 설정을 정의합니다.
+   *
+   * @return OpenAPI 설정
+   */
+  @Bean
+  public OpenAPI customOpenAPI() {
+    return new OpenAPI()
+        .info(new Info()
+            .title("Nody Backend API")
+            .version("0.0.0")
+            .description("Nody 애플리케이션의 백엔드 API 문서입니다."))
+        .servers(List.of(
+            new Server()
+                .url("http://localhost:8080")
+                .description("로컬 개발 서버"),
+            new Server()
+                .url("")
+                .description("운영 서버")))
+        .components(new Components()
+            .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .description("JWT 토큰을 사용한 인증")))
+        .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+  }
+}

--- a/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
+++ b/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
@@ -104,8 +104,8 @@ public class SecurityConfig {
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers("/api/auth/**", "/api/public/**", "/oauth2/**", "/login/**")
             .permitAll()
-            .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
-            .requestMatchers("/openapi.json", "/favicon.ico").permitAll()
+            .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
+            .requestMatchers("/favicon.ico").permitAll()
             .requestMatchers("/actuator/**").permitAll()
             .anyRequest().authenticated())
         .exceptionHandling(exceptions -> exceptions
@@ -137,7 +137,8 @@ public class SecurityConfig {
             .requestMatchers("/api/auth/**", "/api/public/**", "/oauth2/**", "/login/**")
             .permitAll()
             .requestMatchers("/api/admin/**").hasRole("ADMIN")
-            .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/favicon.ico").permitAll()
+            .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
+            .requestMatchers("/favicon.ico").permitAll()
             .requestMatchers("/actuator/**").permitAll()
             .anyRequest().authenticated())
         .exceptionHandling(exceptions -> exceptions

--- a/src/main/java/org/nodystudio/nodybackend/controller/admin/AdminBatchController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/admin/AdminBatchController.java
@@ -2,6 +2,7 @@ package org.nodystudio.nodybackend.controller.admin;
 
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.nodystudio.nodybackend.controller.admin.docs.AdminBatchApiDocs;
 import org.nodystudio.nodybackend.dto.ApiResponse;
 import org.nodystudio.nodybackend.dto.code.SuccessCode;
 import org.nodystudio.nodybackend.service.batch.UserCleanupBatchService;
@@ -10,7 +11,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/admin/batch")
 @RequiredArgsConstructor
-public class AdminBatchController {
+public class AdminBatchController implements AdminBatchApiDocs {
 
   private final UserCleanupBatchService userCleanupBatchService;
 
@@ -30,9 +30,10 @@ public class AdminBatchController {
    *
    * @return 삭제된 사용자 수
    */
+  @Override
   @PostMapping("/user-cleanup")
   @PreAuthorize("hasRole('ADMIN')")
-  public ResponseEntity<ApiResponse<Map<String, Object>>> manualUserCleanup() {
+  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Map<String, Object>>> runUserCleanupBatch() {
     int deletedCount = userCleanupBatchService.manualCleanupExpiredUsers();
 
     Map<String, Object> result = Map.of(
@@ -53,10 +54,11 @@ public class AdminBatchController {
    * @param days 삭제까지 남은 일수 (기본값: 0일 = 즉시 삭제 대상)
    * @return 삭제 예정 사용자 수
    */
+  @Override
   @GetMapping("/user-cleanup/count")
   @PreAuthorize("hasRole('ADMIN')")
-  public ResponseEntity<ApiResponse<Map<String, Object>>> getUserCleanupCount(
-      @RequestParam(value = "days", defaultValue = "0") int days) {
+  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Long>> getExpiredUsersCount() {
+    int days = 0;
 
     if (days < 0 || days > 30) {
       days = 0; // 유효하지 않은 값은 기본값으로 설정
@@ -64,17 +66,9 @@ public class AdminBatchController {
 
     long userCount = userCleanupBatchService.countUsersToBeDeleted(days);
 
-    Map<String, Object> result = Map.of(
-        "usersToBeDeleted", userCount,
-        "daysUntilDeletion", days,
-        "message", days == 0 ?
-            "현재 삭제 대상 사용자 수입니다." :
-            days + "일 후 삭제될 사용자 수입니다."
-    );
-
     return ResponseEntity
         .status(SuccessCode.OK.getStatus())
-        .body(ApiResponse.success(SuccessCode.OK, result));
+        .body(ApiResponse.success(SuccessCode.OK, userCount));
   }
 
   /**
@@ -82,9 +76,10 @@ public class AdminBatchController {
    *
    * @return 배치 작업 상태 정보
    */
+  @Override
   @GetMapping("/user-cleanup/status")
   @PreAuthorize("hasRole('ADMIN')")
-  public ResponseEntity<ApiResponse<Map<String, Object>>> getUserCleanupStatus() {
+  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Map<String, Object>>> getBatchStatus() {
     long immediateCount = userCleanupBatchService.countUsersToBeDeleted(0);
     long weekCount = userCleanupBatchService.countUsersToBeDeleted(7);
     long monthCount = userCleanupBatchService.countUsersToBeDeleted(30);

--- a/src/main/java/org/nodystudio/nodybackend/controller/admin/docs/AdminBatchApiDocs.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/admin/docs/AdminBatchApiDocs.java
@@ -1,0 +1,108 @@
+package org.nodystudio.nodybackend.controller.admin.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+/**
+ * 관리자 배치 작업 API 문서화 인터페이스
+ */
+@Tag(name = "관리자 배치", description = "관리자용 배치 작업 수동 실행 및 모니터링 API")
+@SecurityRequirement(name = "bearerAuth")
+@PreAuthorize("hasRole('ADMIN')")
+public interface AdminBatchApiDocs {
+
+  @Operation(
+      summary = "만료된 탈퇴 사용자 수동 정리",
+      description = "탈퇴 후 30일이 경과한 사용자 데이터를 수동으로 정리합니다. ADMIN 권한이 필요합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "배치 작업 실행 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "인증되지 않은 사용자",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "403",
+          description = "권한 없음 (ADMIN 권한 필요)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Map<String, Object>>> runUserCleanupBatch();
+
+  @Operation(
+      summary = "삭제 예정 사용자 수 조회",
+      description = "탈퇴 후 30일이 경과하여 삭제 예정인 사용자 수를 조회합니다. ADMIN 권한이 필요합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "조회 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "인증되지 않은 사용자",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "403",
+          description = "권한 없음 (ADMIN 권한 필요)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Long>> getExpiredUsersCount();
+
+  @Operation(
+      summary = "배치 작업 상태 정보 조회",
+      description = "사용자 정리 배치 작업의 상태 정보를 조회합니다. ADMIN 권한이 필요합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "상태 정보 조회 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "인증되지 않은 사용자",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "403",
+          description = "권한 없음 (ADMIN 권한 필요)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Map<String, Object>>> getBatchStatus();
+}

--- a/src/main/java/org/nodystudio/nodybackend/controller/auth/AuthController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/auth/AuthController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements org.nodystudio.nodybackend.controller.auth.docs.AuthApiDocs {
 
   private final AuthService authService;
 
@@ -29,8 +29,9 @@ public class AuthController {
    * @param requestDto 토큰 재발급 요청 DTO
    * @return 토큰 재발급 응답
    */
+  @Override
   @PostMapping(value = "/refresh")
-  public ResponseEntity<ApiResponse<TokenResponseDto>> refreshAccessToken(
+  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<TokenResponseDto>> refreshAccessToken(
       @Valid @RequestBody TokenRefreshRequestDto requestDto) {
     TokenResponseDto tokenData = authService.refreshAccessToken(requestDto);
     return ResponseEntity

--- a/src/main/java/org/nodystudio/nodybackend/controller/auth/docs/AuthApiDocs.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/auth/docs/AuthApiDocs.java
@@ -1,0 +1,51 @@
+package org.nodystudio.nodybackend.controller.auth.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.nodystudio.nodybackend.dto.TokenRefreshRequestDto;
+import org.nodystudio.nodybackend.dto.TokenResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * 인증 관련 API 문서화 인터페이스
+ */
+@Tag(name = "인증", description = "JWT 토큰 기반 인증 관련 API")
+public interface AuthApiDocs {
+
+  @Operation(
+      summary = "Access Token 재발급",
+      description = "유효한 Refresh Token을 사용하여 새로운 Access Token을 발급받습니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "토큰 재발급 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "유효하지 않은 Refresh Token",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "잘못된 요청 형식",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<TokenResponseDto>> refreshAccessToken(
+      @Valid @RequestBody TokenRefreshRequestDto requestDto
+  );
+}

--- a/src/main/java/org/nodystudio/nodybackend/controller/log/LogController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/log/LogController.java
@@ -3,6 +3,7 @@ package org.nodystudio.nodybackend.controller.log;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.nodystudio.nodybackend.controller.log.docs.LogApiDocs;
 import org.nodystudio.nodybackend.dto.ApiResponse;
 import org.nodystudio.nodybackend.dto.log.LogCreateRequest;
 import org.nodystudio.nodybackend.dto.log.LogResponse;
@@ -11,9 +12,9 @@ import org.nodystudio.nodybackend.dto.log.LogUpdateRequest;
 import org.nodystudio.nodybackend.dto.thread.ThreadResponse;
 import org.nodystudio.nodybackend.service.log.LogService;
 import org.nodystudio.nodybackend.service.thread.ThreadService;
-import org.nodystudio.nodybackend.util.PageableUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,14 +27,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
 @RequestMapping("/api/logs")
 @RequiredArgsConstructor
-public class LogController {
+public class LogController implements LogApiDocs {
 
   private final LogService logService;
   private final ThreadService threadService;
@@ -42,10 +42,11 @@ public class LogController {
   /**
    * 로그 생성 POST /api/logs
    */
+  @Override
   @PostMapping
-  public ResponseEntity<ApiResponse<LogResponse>> createLog(
-      @Valid @RequestBody LogCreateRequest request,
-      @AuthenticationPrincipal UserDetails userDetails) {
+  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<LogResponse>> createLog(
+      @AuthenticationPrincipal UserDetails userDetails,
+      @Valid @RequestBody LogCreateRequest request) {
 
     log.info("로그 생성 요청 - 사용자: {}", userDetails.getUsername());
 
@@ -58,10 +59,11 @@ public class LogController {
   /**
    * 로그 단건 조회 GET /api/logs/{id}
    */
+  @Override
   @GetMapping("/{id}")
-  public ResponseEntity<ApiResponse<LogResponse>> getLog(
-      @PathVariable Long id,
-      @AuthenticationPrincipal UserDetails userDetails) {
+  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<LogResponse>> getLog(
+      @PathVariable Long id) {
+    UserDetails userDetails = null;
 
     log.info("로그 단건 조회 - ID: {}, 사용자: {}", id,
         userDetails != null ? userDetails.getUsername() : "익명");
@@ -75,10 +77,12 @@ public class LogController {
   /**
    * 로그 목록 조회 (위치 기반, 페이징) GET /api/logs
    */
+  @Override
   @GetMapping
-  public ResponseEntity<ApiResponse<Page<LogResponse>>> getLogs(
+  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<LogResponse>>> getLogs(
       @Valid @ModelAttribute LogSearchRequest searchRequest,
-      @AuthenticationPrincipal UserDetails userDetails) {
+      @PageableDefault(size = 20) Pageable pageable) {
+    UserDetails userDetails = null;
 
     log.info("로그 목록 조회 - 위치: ({}, {}), 반경: {}km, 사용자: {}",
         searchRequest.getLatitude(), searchRequest.getLongitude(),
@@ -94,11 +98,12 @@ public class LogController {
   /**
    * 로그 수정 PUT /api/logs/{id}
    */
+  @Override
   @PutMapping("/{id}")
-  public ResponseEntity<ApiResponse<LogResponse>> updateLog(
+  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<LogResponse>> updateLog(
       @PathVariable Long id,
-      @Valid @RequestBody LogUpdateRequest request,
-      @AuthenticationPrincipal UserDetails userDetails) {
+      @AuthenticationPrincipal UserDetails userDetails,
+      @Valid @RequestBody LogUpdateRequest request) {
 
     log.info("로그 수정 요청 - ID: {}, 사용자: {}", id, userDetails.getUsername());
 
@@ -110,8 +115,9 @@ public class LogController {
   /**
    * 로그 삭제 DELETE /api/logs/{id}
    */
+  @Override
   @DeleteMapping("/{id}")
-  public ResponseEntity<ApiResponse<Void>> deleteLog(
+  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Void>> deleteLog(
       @PathVariable Long id,
       @AuthenticationPrincipal UserDetails userDetails) {
 
@@ -125,19 +131,15 @@ public class LogController {
   /**
    * 특정 로그의 스레드 목록 조회 GET /api/logs/{logId}/threads
    */
+  @Override
   @GetMapping("/{logId}/threads")
-  public ResponseEntity<ApiResponse<Page<ThreadResponse>>> getThreadsByLog(
+  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getLogThreads(
       @PathVariable Long logId,
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "20") int size,
-      @RequestParam(defaultValue = "createdAt") String sortBy,
-      @RequestParam(defaultValue = "desc") String sortDirection,
-      @AuthenticationPrincipal UserDetails userDetails) {
+      @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
 
+    UserDetails userDetails = null;
     log.info("로그 스레드 목록 조회 - 로그ID: {}, 사용자: {}",
         logId, userDetails != null ? userDetails.getUsername() : "익명");
-
-    Pageable pageable = PageableUtils.createThreadPageable(page, size, sortBy, sortDirection);
 
     Page<ThreadResponse> response = threadService.getThreadsByLog(logId,
         userDetails != null ? userDetails.getUsername() : null, pageable);

--- a/src/main/java/org/nodystudio/nodybackend/controller/log/docs/LogApiDocs.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/log/docs/LogApiDocs.java
@@ -1,0 +1,209 @@
+package org.nodystudio.nodybackend.controller.log.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.nodystudio.nodybackend.dto.log.LogCreateRequest;
+import org.nodystudio.nodybackend.dto.log.LogResponse;
+import org.nodystudio.nodybackend.dto.log.LogSearchRequest;
+import org.nodystudio.nodybackend.dto.log.LogUpdateRequest;
+import org.nodystudio.nodybackend.dto.thread.ThreadResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * 로그(게시물) 관리 API 문서화 인터페이스
+ */
+@Tag(name = "로그", description = "로그(게시물) CRUD 및 위치 기반 검색 API")
+@SecurityRequirement(name = "bearerAuth")
+public interface LogApiDocs {
+
+  @Operation(
+      summary = "로그 생성",
+      description = "새로운 로그를 생성합니다. 위치 정보와 내용을 포함할 수 있습니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "201",
+          description = "로그 생성 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "유효하지 않은 요청 데이터",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "인증되지 않은 사용자",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<LogResponse>> createLog(
+      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+      @Valid @RequestBody LogCreateRequest request
+  );
+
+  @Operation(
+      summary = "로그 단건 조회",
+      description = "ID로 특정 로그를 조회합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "로그 조회 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "로그를 찾을 수 없음",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<LogResponse>> getLog(
+      @Parameter(description = "로그 ID") @PathVariable Long id
+  );
+
+  @Operation(
+      summary = "로그 목록 조회",
+      description = "위치 기반으로 로그 목록을 조회합니다. 거리 범위 내의 로그들을 페이징하여 반환합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "로그 목록 조회 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "잘못된 검색 조건",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<LogResponse>>> getLogs(
+      @Valid @ModelAttribute LogSearchRequest searchRequest,
+      @Parameter(hidden = true) @PageableDefault(size = 20) Pageable pageable
+  );
+
+  @Operation(
+      summary = "로그 수정",
+      description = "자신이 작성한 로그를 수정합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "로그 수정 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "유효하지 않은 요청 데이터",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "403",
+          description = "권한 없음 (본인 로그만 수정 가능)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "로그를 찾을 수 없음",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<LogResponse>> updateLog(
+      @Parameter(description = "로그 ID") @PathVariable Long id,
+      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+      @Valid @RequestBody LogUpdateRequest request
+  );
+
+  @Operation(
+      summary = "로그 삭제",
+      description = "자신이 작성한 로그를 삭제합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "로그 삭제 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "403",
+          description = "권한 없음 (본인 로그만 삭제 가능)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "로그를 찾을 수 없음",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Void>> deleteLog(
+      @Parameter(description = "로그 ID") @PathVariable Long id,
+      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails
+  );
+
+  @Operation(
+      summary = "특정 로그의 스레드 목록 조회",
+      description = "특정 로그에 연결된 스레드(댓글) 목록을 조회합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "스레드 목록 조회 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "로그를 찾을 수 없음",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getLogThreads(
+      @Parameter(description = "로그 ID") @PathVariable Long logId,
+      @Parameter(hidden = true) @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
+  );
+}

--- a/src/main/java/org/nodystudio/nodybackend/controller/thread/ThreadController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/thread/ThreadController.java
@@ -45,6 +45,28 @@ public class ThreadController implements ThreadApiDocs {
   }
 
   /**
+   * Pageable을 ThreadSearchRequest로 변환합니다.
+   *
+   * @param pageable 페이지 정보
+   * @param keyword 검색 키워드
+   * @param threadType 스레드 타입
+   * @return 변환된 ThreadSearchRequest
+   */
+  private ThreadSearchRequest createSearchRequestFromPageable(Pageable pageable, String keyword, String threadType) {
+    return ThreadSearchRequest.builder()
+        .page(pageable.getPageNumber())
+        .size(pageable.getPageSize())
+        .sortBy(pageable.getSort().iterator().hasNext() ? pageable.getSort().iterator().next()
+            .getProperty() : "createdAt")
+        .sortDirection(
+            pageable.getSort().iterator().hasNext() && pageable.getSort().iterator().next()
+                .isDescending() ? "desc" : "asc")
+        .keyword(keyword)
+        .threadType(threadType)
+        .build();
+  }
+
+  /**
    * 스레드 생성 POST /api/threads
    */
   @Override
@@ -85,7 +107,7 @@ public class ThreadController implements ThreadApiDocs {
    */
   @Override
   @GetMapping
-  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getThreads(
+  public ResponseEntity<ApiResponse<Page<ThreadResponse>>> getThreads(
       @Valid @ModelAttribute ThreadSearchRequest searchRequest,
       @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
     UserDetails userDetails = null;
@@ -141,7 +163,7 @@ public class ThreadController implements ThreadApiDocs {
    */
   @Override
   @GetMapping("/independent")
-  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getIndependentThreads(
+  public ResponseEntity<ApiResponse<Page<ThreadResponse>>> getIndependentThreads(
       @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
     UserDetails userDetails = null;
     String keyword = null;
@@ -149,17 +171,7 @@ public class ThreadController implements ThreadApiDocs {
     log.info("독립 스레드 목록 조회 - 키워드: {}, 사용자: {}", keyword,
         getUserDisplayName(userDetails));
 
-    ThreadSearchRequest searchRequest = ThreadSearchRequest.builder()
-        .page(pageable.getPageNumber())
-        .size(pageable.getPageSize())
-        .sortBy(pageable.getSort().iterator().hasNext() ? pageable.getSort().iterator().next()
-            .getProperty() : "createdAt")
-        .sortDirection(
-            pageable.getSort().iterator().hasNext() && pageable.getSort().iterator().next()
-                .isDescending() ? "desc" : "asc")
-        .keyword(keyword)
-        .threadType("independent")
-        .build();
+    ThreadSearchRequest searchRequest = createSearchRequestFromPageable(pageable, keyword, "independent");
 
     Page<ThreadResponse> response = threadService.searchThreads(searchRequest,
         userDetails != null ? userDetails.getUsername() : null);
@@ -172,7 +184,7 @@ public class ThreadController implements ThreadApiDocs {
    */
   @Override
   @GetMapping("/linked")
-  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getLinkedThreads(
+  public ResponseEntity<ApiResponse<Page<ThreadResponse>>> getLinkedThreads(
       @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
     UserDetails userDetails = null;
     String keyword = null;
@@ -180,17 +192,7 @@ public class ThreadController implements ThreadApiDocs {
     log.info("로그 연결 스레드 목록 조회 - 키워드: {}, 사용자: {}", keyword,
         getUserDisplayName(userDetails));
 
-    ThreadSearchRequest searchRequest = ThreadSearchRequest.builder()
-        .page(pageable.getPageNumber())
-        .size(pageable.getPageSize())
-        .sortBy(pageable.getSort().iterator().hasNext() ? pageable.getSort().iterator().next()
-            .getProperty() : "createdAt")
-        .sortDirection(
-            pageable.getSort().iterator().hasNext() && pageable.getSort().iterator().next()
-                .isDescending() ? "desc" : "asc")
-        .keyword(keyword)
-        .threadType("linked")
-        .build();
+    ThreadSearchRequest searchRequest = createSearchRequestFromPageable(pageable, keyword, "linked");
 
     Page<ThreadResponse> response = threadService.searchThreads(searchRequest,
         userDetails != null ? userDetails.getUsername() : null);

--- a/src/main/java/org/nodystudio/nodybackend/controller/thread/ThreadController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/thread/ThreadController.java
@@ -3,7 +3,7 @@ package org.nodystudio.nodybackend.controller.thread;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.nodystudio.nodybackend.domain.user.User;
+import org.nodystudio.nodybackend.controller.thread.docs.ThreadApiDocs;
 import org.nodystudio.nodybackend.dto.ApiResponse;
 import org.nodystudio.nodybackend.dto.thread.ThreadCreateRequest;
 import org.nodystudio.nodybackend.dto.thread.ThreadResponse;
@@ -11,9 +11,12 @@ import org.nodystudio.nodybackend.dto.thread.ThreadSearchRequest;
 import org.nodystudio.nodybackend.dto.thread.ThreadUpdateRequest;
 import org.nodystudio.nodybackend.service.thread.ThreadService;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -22,14 +25,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
 @RequestMapping("/api/threads")
 @RequiredArgsConstructor
-public class ThreadController {
+public class ThreadController implements ThreadApiDocs {
 
   private final ThreadService threadService;
 
@@ -38,22 +40,23 @@ public class ThreadController {
   /**
    * 로그에 표시할 사용자 정보를 안전하게 가져옵니다. 인증되지 않은 사용자의 경우 "익명"을 반환합니다.
    */
-  private String getUserDisplayName(User user) {
-    return user != null ? user.getEmail() : "익명";
+  private String getUserDisplayName(UserDetails userDetails) {
+    return userDetails != null ? userDetails.getUsername() : "익명";
   }
 
   /**
    * 스레드 생성 POST /api/threads
    */
+  @Override
   @PostMapping
   public ResponseEntity<ApiResponse<ThreadResponse>> createThread(
-      @Valid @RequestBody ThreadCreateRequest request,
-      @AuthenticationPrincipal User user) {
+      @AuthenticationPrincipal UserDetails userDetails,
+      @Valid @RequestBody ThreadCreateRequest request) {
 
     log.info("스레드 생성 요청 - 사용자: {}",
-        getUserDisplayName(user));
+        getUserDisplayName(userDetails));
 
-    ThreadResponse response = threadService.createThread(request, user.getEmail());
+    ThreadResponse response = threadService.createThread(request, userDetails.getUsername());
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResponse.success("스레드가 성공적으로 생성되었습니다.", response));
@@ -62,16 +65,17 @@ public class ThreadController {
   /**
    * 스레드 단건 조회 GET /api/threads/{id}
    */
+  @Override
   @GetMapping("/{id}")
   public ResponseEntity<ApiResponse<ThreadResponse>> getThread(
-      @PathVariable Long id,
-      @AuthenticationPrincipal User user) {
+      @PathVariable Long id) {
+    UserDetails userDetails = null;
 
     log.info("스레드 단건 조회 - ID: {}, 사용자: {}",
-        id, getUserDisplayName(user));
+        id, getUserDisplayName(userDetails));
 
     ThreadResponse response = threadService.getThread(
-        id, user != null ? user.getEmail() : null);
+        id, userDetails != null ? userDetails.getUsername() : null);
 
     return ResponseEntity.ok(ApiResponse.success("스레드 조회가 완료되었습니다.", response));
   }
@@ -79,19 +83,21 @@ public class ThreadController {
   /**
    * 스레드 목록 조회 (검색, 필터링, 페이징) GET /api/threads
    */
+  @Override
   @GetMapping
-  public ResponseEntity<ApiResponse<Page<ThreadResponse>>> getThreads(
+  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getThreads(
       @Valid @ModelAttribute ThreadSearchRequest searchRequest,
-      @AuthenticationPrincipal User user) {
+      @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
+    UserDetails userDetails = null;
 
     log.info("스레드 목록 조회 - 키워드: {}, 타입: {}, 로그ID: {}, 사용자: {}",
         searchRequest.getKeyword(),
         searchRequest.getThreadType(),
         searchRequest.getLogId(),
-        getUserDisplayName(user));
+        getUserDisplayName(userDetails));
 
     Page<ThreadResponse> response = threadService.searchThreads(searchRequest,
-        user != null ? user.getEmail() : null);
+        userDetails != null ? userDetails.getUsername() : null);
 
     return ResponseEntity.ok(ApiResponse.success("스레드 목록 조회가 완료되었습니다.", response));
   }
@@ -99,15 +105,16 @@ public class ThreadController {
   /**
    * 스레드 수정 PUT /api/threads/{id}
    */
+  @Override
   @PutMapping("/{id}")
   public ResponseEntity<ApiResponse<ThreadResponse>> updateThread(
       @PathVariable Long id,
-      @Valid @RequestBody ThreadUpdateRequest request,
-      @AuthenticationPrincipal User user) {
+      @AuthenticationPrincipal UserDetails userDetails,
+      @Valid @RequestBody ThreadUpdateRequest request) {
 
-    log.info("스레드 수정 요청 - ID: {}, 사용자: {}", id, getUserDisplayName(user));
+    log.info("스레드 수정 요청 - ID: {}, 사용자: {}", id, getUserDisplayName(userDetails));
 
-    ThreadResponse response = threadService.updateThread(id, request, user.getEmail());
+    ThreadResponse response = threadService.updateThread(id, request, userDetails.getUsername());
 
     return ResponseEntity.ok(ApiResponse.success("스레드가 성공적으로 수정되었습니다.", response));
   }
@@ -115,14 +122,15 @@ public class ThreadController {
   /**
    * 스레드 삭제 DELETE /api/threads/{id}
    */
+  @Override
   @DeleteMapping("/{id}")
-  public ResponseEntity<ApiResponse<Void>> deleteThread(
+  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Void>> deleteThread(
       @PathVariable Long id,
-      @AuthenticationPrincipal User user) {
+      @AuthenticationPrincipal UserDetails userDetails) {
 
-    log.info("스레드 삭제 요청 - ID: {}, 사용자: {}", id, getUserDisplayName(user));
+    log.info("스레드 삭제 요청 - ID: {}, 사용자: {}", id, getUserDisplayName(userDetails));
 
-    threadService.deleteThread(id, user.getEmail());
+    threadService.deleteThread(id, userDetails.getUsername());
 
     return ResponseEntity.ok(ApiResponse.success("스레드가 성공적으로 삭제되었습니다.", null));
   }
@@ -131,29 +139,30 @@ public class ThreadController {
   /**
    * 독립 스레드 목록 조회 (로그에 연결되지 않은 스레드) GET /api/threads/independent
    */
+  @Override
   @GetMapping("/independent")
-  public ResponseEntity<ApiResponse<Page<ThreadResponse>>> getIndependentThreads(
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "20") int size,
-      @RequestParam(defaultValue = "createdAt") String sortBy,
-      @RequestParam(defaultValue = "desc") String sortDirection,
-      @RequestParam(required = false) String keyword,
-      @AuthenticationPrincipal User user) {
+  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getIndependentThreads(
+      @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
+    UserDetails userDetails = null;
+    String keyword = null;
 
     log.info("독립 스레드 목록 조회 - 키워드: {}, 사용자: {}", keyword,
-        getUserDisplayName(user));
+        getUserDisplayName(userDetails));
 
     ThreadSearchRequest searchRequest = ThreadSearchRequest.builder()
-        .page(page)
-        .size(size)
-        .sortBy(sortBy)
-        .sortDirection(sortDirection)
+        .page(pageable.getPageNumber())
+        .size(pageable.getPageSize())
+        .sortBy(pageable.getSort().iterator().hasNext() ? pageable.getSort().iterator().next()
+            .getProperty() : "createdAt")
+        .sortDirection(
+            pageable.getSort().iterator().hasNext() && pageable.getSort().iterator().next()
+                .isDescending() ? "desc" : "asc")
         .keyword(keyword)
         .threadType("independent")
         .build();
 
     Page<ThreadResponse> response = threadService.searchThreads(searchRequest,
-        user != null ? user.getEmail() : null);
+        userDetails != null ? userDetails.getUsername() : null);
 
     return ResponseEntity.ok(ApiResponse.success("독립 스레드 목록 조회가 완료되었습니다.", response));
   }
@@ -161,29 +170,30 @@ public class ThreadController {
   /**
    * 로그 연결 스레드 목록 조회 (로그에 연결된 스레드) GET /api/threads/linked
    */
+  @Override
   @GetMapping("/linked")
-  public ResponseEntity<ApiResponse<Page<ThreadResponse>>> getLinkedThreads(
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "20") int size,
-      @RequestParam(defaultValue = "createdAt") String sortBy,
-      @RequestParam(defaultValue = "desc") String sortDirection,
-      @RequestParam(required = false) String keyword,
-      @AuthenticationPrincipal User user) {
+  public ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getLinkedThreads(
+      @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
+    UserDetails userDetails = null;
+    String keyword = null;
 
     log.info("로그 연결 스레드 목록 조회 - 키워드: {}, 사용자: {}", keyword,
-        getUserDisplayName(user));
+        getUserDisplayName(userDetails));
 
     ThreadSearchRequest searchRequest = ThreadSearchRequest.builder()
-        .page(page)
-        .size(size)
-        .sortBy(sortBy)
-        .sortDirection(sortDirection)
+        .page(pageable.getPageNumber())
+        .size(pageable.getPageSize())
+        .sortBy(pageable.getSort().iterator().hasNext() ? pageable.getSort().iterator().next()
+            .getProperty() : "createdAt")
+        .sortDirection(
+            pageable.getSort().iterator().hasNext() && pageable.getSort().iterator().next()
+                .isDescending() ? "desc" : "asc")
         .keyword(keyword)
         .threadType("linked")
         .build();
 
     Page<ThreadResponse> response = threadService.searchThreads(searchRequest,
-        user != null ? user.getEmail() : null);
+        userDetails != null ? userDetails.getUsername() : null);
 
     return ResponseEntity.ok(ApiResponse.success("로그 연결 스레드 목록 조회가 완료되었습니다.", response));
   }

--- a/src/main/java/org/nodystudio/nodybackend/controller/thread/docs/ThreadApiDocs.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/thread/docs/ThreadApiDocs.java
@@ -1,0 +1,214 @@
+package org.nodystudio.nodybackend.controller.thread.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.nodystudio.nodybackend.dto.thread.ThreadCreateRequest;
+import org.nodystudio.nodybackend.dto.thread.ThreadResponse;
+import org.nodystudio.nodybackend.dto.thread.ThreadSearchRequest;
+import org.nodystudio.nodybackend.dto.thread.ThreadUpdateRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * 스레드(댓글/답글) 관리 API 문서화 인터페이스
+ */
+@Tag(name = "스레드", description = "스레드(댓글/답글) CRUD 및 검색 API")
+@SecurityRequirement(name = "bearerAuth")
+public interface ThreadApiDocs {
+
+  @Operation(
+      summary = "스레드 생성",
+      description = "새로운 스레드를 생성합니다. 로그에 연결된 스레드나 독립적인 스레드를 생성할 수 있습니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "201",
+          description = "스레드 생성 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "유효하지 않은 요청 데이터",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "인증되지 않은 사용자",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<ThreadResponse>> createThread(
+      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+      @Valid @RequestBody ThreadCreateRequest request
+  );
+
+  @Operation(
+      summary = "스레드 단건 조회",
+      description = "ID로 특정 스레드를 조회합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "스레드 조회 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "스레드를 찾을 수 없음",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<ThreadResponse>> getThread(
+      @Parameter(description = "스레드 ID") @PathVariable Long id
+  );
+
+  @Operation(
+      summary = "스레드 목록 조회",
+      description = "스레드 목록을 검색 조건에 따라 조회합니다. 검색어, 로그 ID, 부모 스레드 ID 등으로 필터링할 수 있습니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "스레드 목록 조회 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "잘못된 검색 조건",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getThreads(
+      @Valid @ModelAttribute ThreadSearchRequest searchRequest,
+      @Parameter(hidden = true) @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
+  );
+
+  @Operation(
+      summary = "스레드 수정",
+      description = "자신이 작성한 스레드를 수정합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "스레드 수정 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "유효하지 않은 요청 데이터",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "403",
+          description = "권한 없음 (본인 스레드만 수정 가능)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "스레드를 찾을 수 없음",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<ThreadResponse>> updateThread(
+      @Parameter(description = "스레드 ID") @PathVariable Long id,
+      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+      @Valid @RequestBody ThreadUpdateRequest request
+  );
+
+  @Operation(
+      summary = "스레드 삭제",
+      description = "자신이 작성한 스레드를 삭제합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "스레드 삭제 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "403",
+          description = "권한 없음 (본인 스레드만 삭제 가능)",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "스레드를 찾을 수 없음",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Void>> deleteThread(
+      @Parameter(description = "스레드 ID") @PathVariable Long id,
+      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails
+  );
+
+  @Operation(
+      summary = "독립 스레드 목록 조회",
+      description = "로그에 연결되지 않은 독립 스레드 목록을 조회합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "독립 스레드 목록 조회 성공",
+          useReturnTypeSchema = true
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getIndependentThreads(
+      @Parameter(hidden = true) @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
+  );
+
+  @Operation(
+      summary = "로그 연결 스레드 목록 조회",
+      description = "로그에 연결된 스레드 목록을 조회합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "로그 연결 스레드 목록 조회 성공",
+          useReturnTypeSchema = true
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getLinkedThreads(
+      @Parameter(hidden = true) @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
+  );
+}

--- a/src/main/java/org/nodystudio/nodybackend/controller/user/UserController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/user/UserController.java
@@ -80,7 +80,7 @@ public class UserController implements UserApiDocs {
    */
   @Override
   @DeleteMapping(value = "/me")
-  public ResponseEntity<ApiResponse<Void>> deleteAccount(
+  public ResponseEntity<ApiResponse<Void>> deactivateAccount(
       @AuthenticationPrincipal Object user) {
     User currentUser = (User) user;
     userService.deactivateAccount(currentUser.getId().toString());

--- a/src/main/java/org/nodystudio/nodybackend/controller/user/UserController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/user/UserController.java
@@ -2,6 +2,7 @@ package org.nodystudio.nodybackend.controller.user;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.nodystudio.nodybackend.controller.user.docs.UserApiDocs;
 import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.dto.ApiResponse;
 import org.nodystudio.nodybackend.dto.code.SuccessCode;
@@ -23,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/user")
 @RequiredArgsConstructor
-public class UserController {
+public class UserController implements UserApiDocs {
 
   private final UserService userService;
 
@@ -38,10 +39,12 @@ public class UserController {
    * @param user 인증된 사용자 정보 (Spring Security에 의해 보장됨)
    * @return UserDetailResponseDto 사용자 정보
    */
+  @Override
   @GetMapping(value = "/me")
   public ResponseEntity<ApiResponse<UserDetailResponseDto>> getCurrentUser(
-      @AuthenticationPrincipal User user) {
-    UserDetailResponseDto userDetail = userService.getCurrentUser(user.getId().toString());
+      @AuthenticationPrincipal Object user) {
+    User currentUser = (User) user;
+    UserDetailResponseDto userDetail = userService.getCurrentUser(currentUser.getId().toString());
 
     return ResponseEntity
         .status(SuccessCode.OK.getStatus())
@@ -55,11 +58,13 @@ public class UserController {
    * @param requestDto 닉네임 변경 요청 DTO
    * @return UserDetailResponseDto 변경된 사용자 정보
    */
+  @Override
   @PutMapping(value = "/nickname")
   public ResponseEntity<ApiResponse<UserDetailResponseDto>> updateNickname(
-      @AuthenticationPrincipal User user,
+      @AuthenticationPrincipal Object user,
       @Valid @RequestBody UpdateNicknameRequestDto requestDto) {
-    UserDetailResponseDto updatedUser = userService.updateNickname(user.getId().toString(),
+    User currentUser = (User) user;
+    UserDetailResponseDto updatedUser = userService.updateNickname(currentUser.getId().toString(),
         requestDto);
 
     return ResponseEntity
@@ -73,10 +78,12 @@ public class UserController {
    * @param user 인증된 사용자 정보 (@ignore)
    * @return 탈퇴 처리 결과
    */
+  @Override
   @DeleteMapping(value = "/me")
-  public ResponseEntity<ApiResponse<Void>> deactivateAccount(
-      @AuthenticationPrincipal User user) {
-    userService.deactivateAccount(user.getId().toString());
+  public ResponseEntity<ApiResponse<Void>> deleteAccount(
+      @AuthenticationPrincipal Object user) {
+    User currentUser = (User) user;
+    userService.deactivateAccount(currentUser.getId().toString());
 
     return ResponseEntity
         .status(SuccessCode.OK.getStatus())

--- a/src/main/java/org/nodystudio/nodybackend/controller/user/docs/UserApiDocs.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/user/docs/UserApiDocs.java
@@ -104,7 +104,7 @@ public interface UserApiDocs {
           )
       )
   })
-  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Void>> deleteAccount(
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Void>> deactivateAccount(
       @Parameter(hidden = true) @AuthenticationPrincipal Object currentUser
   );
 }

--- a/src/main/java/org/nodystudio/nodybackend/controller/user/docs/UserApiDocs.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/user/docs/UserApiDocs.java
@@ -1,0 +1,110 @@
+package org.nodystudio.nodybackend.controller.user.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.nodystudio.nodybackend.dto.user.UpdateNicknameRequestDto;
+import org.nodystudio.nodybackend.dto.user.UserDetailResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * 사용자 관리 API 문서화 인터페이스
+ */
+@Tag(name = "사용자", description = "사용자 정보 관리 및 계정 관련 API")
+@SecurityRequirement(name = "bearerAuth")
+public interface UserApiDocs {
+
+  @Operation(
+      summary = "현재 사용자 정보 조회",
+      description = "로그인한 사용자의 상세 정보를 조회합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "사용자 정보 조회 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "인증되지 않은 사용자",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<UserDetailResponseDto>> getCurrentUser(
+      @Parameter(hidden = true) @AuthenticationPrincipal Object currentUser
+  );
+
+  @Operation(
+      summary = "닉네임 변경",
+      description = "현재 사용자의 닉네임을 변경합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "닉네임 변경 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "유효하지 않은 닉네임 형식",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "인증되지 않은 사용자",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      ),
+      @ApiResponse(
+          responseCode = "409",
+          description = "이미 사용 중인 닉네임",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<UserDetailResponseDto>> updateNickname(
+      @Parameter(hidden = true) @AuthenticationPrincipal Object currentUser,
+      @Valid @RequestBody UpdateNicknameRequestDto requestDto
+  );
+
+  @Operation(
+      summary = "계정 탈퇴",
+      description = "현재 사용자의 계정을 탈퇴 처리합니다. 30일 후 완전히 삭제됩니다."
+  )
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "계정 탈퇴 처리 성공",
+          useReturnTypeSchema = true
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "인증되지 않은 사용자",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
+          )
+      )
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Void>> deleteAccount(
+      @Parameter(hidden = true) @AuthenticationPrincipal Object currentUser
+  );
+}

--- a/src/main/java/org/nodystudio/nodybackend/dto/TokenRefreshRequestDto.java
+++ b/src/main/java/org/nodystudio/nodybackend/dto/TokenRefreshRequestDto.java
@@ -1,5 +1,7 @@
 package org.nodystudio.nodybackend.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,7 +9,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Access Token 재발급 요청 DTO")
 public class TokenRefreshRequestDto {
 
+  @NotBlank(message = "Refresh Token은 필수입니다")
+  @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", required = true)
   private String refreshToken;
 }

--- a/src/main/java/org/nodystudio/nodybackend/dto/TokenResponseDto.java
+++ b/src/main/java/org/nodystudio/nodybackend/dto/TokenResponseDto.java
@@ -1,5 +1,6 @@
 package org.nodystudio.nodybackend.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,10 +10,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "JWT 토큰 응답 DTO")
 public class TokenResponseDto {
 
+  @Schema(description = "권한 부여 타입", example = "Bearer")
   private String grantType;
+
+  @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
   private String accessToken;
+
+  @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
   private String refreshToken;
+
+  @Schema(description = "Access Token 만료 시간 (초 단위)", example = "3600")
   private Long accessTokenExpiresIn;
 }

--- a/src/main/resources/smart-doc.json
+++ b/src/main/resources/smart-doc.json
@@ -1,5 +1,0 @@
-{
-  "outPath": "src/main/resources/static",
-  "allInOne": true,
-  "componentType": "NORMAL"
-}

--- a/src/test/java/org/nodystudio/nodybackend/controller/log/LogControllerTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/controller/log/LogControllerTest.java
@@ -36,6 +36,8 @@ import org.nodystudio.nodybackend.service.log.LogService;
 import org.nodystudio.nodybackend.service.thread.ThreadService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -99,8 +101,8 @@ class LogControllerTest {
         .willReturn(testLogResponse);
 
     // when
-    ResponseEntity<ApiResponse<LogResponse>> response = logController.createLog(request,
-        mockUserDetails);
+    ResponseEntity<ApiResponse<LogResponse>> response = logController.createLog(mockUserDetails,
+        request);
 
     // then
     assertEquals(201, response.getStatusCode().value());
@@ -118,10 +120,10 @@ class LogControllerTest {
   @DisplayName("GET /api/logs/{id} - 로그 단건 조회 API 테스트")
   void getLog_Success() {
     // given
-    given(logService.getLog(1L, "test@example.com")).willReturn(testLogResponse);
+    given(logService.getLog(1L, null)).willReturn(testLogResponse);
 
     // when
-    ResponseEntity<ApiResponse<LogResponse>> response = logController.getLog(1L, mockUserDetails);
+    ResponseEntity<ApiResponse<LogResponse>> response = logController.getLog(1L);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -133,7 +135,7 @@ class LogControllerTest {
     assertEquals(1L, body.getData().getViewCount());
     assertEquals("로그 조회가 완료되었습니다.", body.getMessage());
 
-    verify(logService).getLog(1L, "test@example.com");
+    verify(logService).getLog(1L, null);
   }
 
   @Test
@@ -143,7 +145,7 @@ class LogControllerTest {
     given(logService.getLog(1L, null)).willReturn(testLogResponse);
 
     // when
-    ResponseEntity<ApiResponse<LogResponse>> response = logController.getLog(1L, null);
+    ResponseEntity<ApiResponse<LogResponse>> response = logController.getLog(1L);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -168,12 +170,13 @@ class LogControllerTest {
         .size(20)
         .build();
 
-    given(logService.searchLogs(any(LogSearchRequest.class), eq("test@example.com"))).willReturn(
+    given(logService.searchLogs(any(LogSearchRequest.class), eq(null))).willReturn(
         logPage);
 
     // when
+    Pageable pageable = PageRequest.of(0, 20);
     ResponseEntity<ApiResponse<Page<LogResponse>>> response = logController.getLogs(searchRequest,
-        mockUserDetails);
+        pageable);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -185,7 +188,7 @@ class LogControllerTest {
     assertEquals(1L, body.getData().getContent().get(0).getId());
     assertEquals("로그 목록 조회가 완료되었습니다.", body.getMessage());
 
-    verify(logService).searchLogs(any(LogSearchRequest.class), eq("test@example.com"));
+    verify(logService).searchLogs(any(LogSearchRequest.class), eq(null));
   }
 
   @Test
@@ -214,8 +217,7 @@ class LogControllerTest {
         .willReturn(updatedResponse);
 
     // when
-    ResponseEntity<ApiResponse<LogResponse>> response = logController.updateLog(1L, request,
-        mockUserDetails);
+    ResponseEntity<ApiResponse<LogResponse>> response = logController.updateLog(1L, mockUserDetails, request);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -296,11 +298,12 @@ class LogControllerTest {
         .build();
 
     Page<ThreadResponse> threadPage = new PageImpl<>(Arrays.asList(threadResponse));
-    given(threadService.getThreadsByLog(eq(logId), eq("test@example.com"), any())).willReturn(threadPage);
+    given(threadService.getThreadsByLog(eq(logId), eq(null), any())).willReturn(threadPage);
 
     // when
-    ResponseEntity<ApiResponse<Page<ThreadResponse>>> response = logController.getThreadsByLog(
-        logId, 0, 20, "createdAt", "desc", mockUserDetails);
+    Pageable pageable = PageRequest.of(0, 20);
+    ResponseEntity<ApiResponse<Page<ThreadResponse>>> response = logController.getLogThreads(
+        logId, pageable);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -311,7 +314,7 @@ class LogControllerTest {
     assertEquals("테스트 스레드 내용", body.getData().getContent().get(0).getContent());
     assertEquals("로그 스레드 목록 조회가 완료되었습니다.", body.getMessage());
 
-    verify(threadService).getThreadsByLog(eq(logId), eq("test@example.com"), any());
+    verify(threadService).getThreadsByLog(eq(logId), eq(null), any());
   }
 
   @Test
@@ -338,8 +341,9 @@ class LogControllerTest {
     given(threadService.getThreadsByLog(eq(logId), isNull(), any())).willReturn(threadPage);
 
     // when
-    ResponseEntity<ApiResponse<Page<ThreadResponse>>> response = logController.getThreadsByLog(
-        logId, 0, 20, "createdAt", "desc", null);
+    Pageable pageable = PageRequest.of(0, 20);
+    ResponseEntity<ApiResponse<Page<ThreadResponse>>> response = logController.getLogThreads(
+        logId, pageable);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -359,11 +363,12 @@ class LogControllerTest {
     // given
     Long logId = 999L;
     Page<ThreadResponse> emptyPage = new PageImpl<>(Collections.emptyList());
-    given(threadService.getThreadsByLog(eq(logId), eq("test@example.com"), any())).willReturn(emptyPage);
+    given(threadService.getThreadsByLog(eq(logId), eq(null), any())).willReturn(emptyPage);
 
     // when
-    ResponseEntity<ApiResponse<Page<ThreadResponse>>> response = logController.getThreadsByLog(
-        logId, 0, 20, "createdAt", "desc", mockUserDetails);
+    Pageable pageable = PageRequest.of(0, 20);
+    ResponseEntity<ApiResponse<Page<ThreadResponse>>> response = logController.getLogThreads(
+        logId, pageable);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -373,6 +378,6 @@ class LogControllerTest {
     assertTrue(body.getData().getContent().isEmpty());
     assertEquals("로그 스레드 목록 조회가 완료되었습니다.", body.getMessage());
 
-    verify(threadService).getThreadsByLog(eq(logId), eq("test@example.com"), any());
+    verify(threadService).getThreadsByLog(eq(logId), eq(null), any());
   }
 }

--- a/src/test/java/org/nodystudio/nodybackend/controller/thread/ThreadControllerTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/controller/thread/ThreadControllerTest.java
@@ -26,8 +26,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.nodystudio.nodybackend.domain.user.RoleType;
-import org.nodystudio.nodybackend.domain.user.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import java.util.Collection;
+import java.util.List;
 import org.nodystudio.nodybackend.dto.ApiResponse;
 import org.nodystudio.nodybackend.dto.code.ErrorCode;
 import org.nodystudio.nodybackend.dto.thread.ThreadCreateRequest;
@@ -52,7 +55,7 @@ class ThreadControllerTest {
   private ThreadController threadController;
 
   private ThreadResponse threadResponse;
-  private User mockUser;
+  private UserDetails mockUserDetails;
   private Validator validator;
 
   @BeforeEach
@@ -62,16 +65,43 @@ class ThreadControllerTest {
       validator = factory.getValidator();
     }
 
-    // Mock User 생성
-    mockUser = User.builder()
-        .id(1L)
-        .provider("google")
-        .socialId("123456789")
-        .email("test@example.com")
-        .nickname("테스트유저")
-        .role(RoleType.USER)
-        .isActive(true)
-        .build();
+    // Mock UserDetails 생성
+    mockUserDetails = new UserDetails() {
+      @Override
+      public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+      }
+
+      @Override
+      public String getPassword() {
+        return null;
+      }
+
+      @Override
+      public String getUsername() {
+        return "test@example.com";
+      }
+
+      @Override
+      public boolean isAccountNonExpired() {
+        return true;
+      }
+
+      @Override
+      public boolean isAccountNonLocked() {
+        return true;
+      }
+
+      @Override
+      public boolean isCredentialsNonExpired() {
+        return true;
+      }
+
+      @Override
+      public boolean isEnabled() {
+        return true;
+      }
+    };
 
     UserSummaryResponse userResponse = UserSummaryResponse.builder()
         .id(1L)
@@ -121,8 +151,8 @@ class ThreadControllerTest {
         .willReturn(createResponse);
 
     // when
-    ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.createThread(request,
-        mockUser);
+    ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.createThread(
+        mockUserDetails, request);
 
     // then
     assertEquals(201, response.getStatusCode().value());
@@ -140,10 +170,10 @@ class ThreadControllerTest {
   @DisplayName("GET /api/threads/{id} - 스레드 단건 조회 API 테스트")
   void getThread_Success() {
     // given
-    given(threadService.getThread(1L, "test@example.com")).willReturn(threadResponse);
+    given(threadService.getThread(1L, null)).willReturn(threadResponse);
 
     // when
-    ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.getThread(1L, mockUser);
+    ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.getThread(1L);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -154,7 +184,7 @@ class ThreadControllerTest {
     assertEquals("테스트 스레드 내용", body.getData().getContent());
     assertEquals("스레드 조회가 완료되었습니다.", body.getMessage());
 
-    verify(threadService).getThread(1L, "test@example.com");
+    verify(threadService).getThread(1L, null);
   }
 
   @Test
@@ -164,7 +194,7 @@ class ThreadControllerTest {
     given(threadService.getThread(1L, null)).willReturn(threadResponse);
 
     // when
-    ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.getThread(1L, null);
+    ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.getThread(1L);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -183,7 +213,7 @@ class ThreadControllerTest {
     willDoNothing().given(threadService).deleteThread(1L, "test@example.com");
 
     // when
-    ResponseEntity<ApiResponse<Void>> response = threadController.deleteThread(1L, mockUser);
+    ResponseEntity<ApiResponse<Void>> response = threadController.deleteThread(1L, mockUserDetails);
 
     // then
     assertEquals(200, response.getStatusCode().value());

--- a/src/test/java/org/nodystudio/nodybackend/integration/ThreadIntegrationTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/integration/ThreadIntegrationTest.java
@@ -28,7 +28,12 @@ import org.nodystudio.nodybackend.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
+import java.util.Collection;
+import java.util.List;
 
 @DisplayName("Thread 통합 테스트")
 class ThreadIntegrationTest extends BaseIntegrationTest {
@@ -84,12 +89,55 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
         .build());
   }
 
+  /**
+   * User 객체를 UserDetails로 변환하는 헬퍼 메서드
+   */
+  private UserDetails createUserDetails(User user) {
+    return new UserDetails() {
+      @Override
+      public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+      }
+
+      @Override
+      public String getPassword() {
+        return null;
+      }
+
+      @Override
+      public String getUsername() {
+        return user.getEmail();
+      }
+
+      @Override
+      public boolean isAccountNonExpired() {
+        return true;
+      }
+
+      @Override
+      public boolean isAccountNonLocked() {
+        return true;
+      }
+
+      @Override
+      public boolean isCredentialsNonExpired() {
+        return true;
+      }
+
+      @Override
+      public boolean isEnabled() {
+        return user.getIsActive();
+      }
+    };
+  }
+
   @Test
   @DisplayName("독립 스레드 생성 성공")
   void createIndependentThread_Success() throws Exception {
     // given
+    UserDetails userDetails = createUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-        testUser, null, testUser.getRoles());
+        userDetails, null, userDetails.getAuthorities());
 
     ThreadCreateRequest request = ThreadCreateRequest.builder()
         .content("독립 스레드 내용")
@@ -113,8 +161,9 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
   @DisplayName("로그 연결 스레드 생성 성공")
   void createLogLinkedThread_Success() throws Exception {
     // given
+    UserDetails userDetails = createUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-        testUser, null, testUser.getRoles());
+        userDetails, null, userDetails.getAuthorities());
 
     ThreadCreateRequest request = ThreadCreateRequest.builder()
         .content("로그 연결 스레드 내용")
@@ -139,8 +188,9 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
   @DisplayName("스레드 단건 조회 성공")
   void getThread_Success() throws Exception {
     // given
+    UserDetails userDetails = createUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-        testUser, null, testUser.getRoles());
+        userDetails, null, userDetails.getAuthorities());
 
     // 스레드 생성
     ThreadCreateRequest createRequest = ThreadCreateRequest.builder()
@@ -171,8 +221,9 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
   @DisplayName("인증 없이 공개 스레드 조회 성공")
   void getPublicThread_WithoutAuth_Success() throws Exception {
     // given - 공개 스레드 생성
+    UserDetails userDetails = createUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-        testUser, null, testUser.getRoles());
+        userDetails, null, userDetails.getAuthorities());
 
     ThreadCreateRequest createRequest = ThreadCreateRequest.builder()
         .content("공개 스레드 내용")
@@ -200,8 +251,9 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
   @DisplayName("스레드 수정 성공")
   void updateThread_Success() throws Exception {
     // given
+    UserDetails userDetails = createUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-        testUser, null, testUser.getRoles());
+        userDetails, null, userDetails.getAuthorities());
 
     // 스레드 생성
     ThreadCreateRequest createRequest = ThreadCreateRequest.builder()
@@ -240,8 +292,9 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
   @DisplayName("스레드 삭제 성공")
   void deleteThread_Success() throws Exception {
     // given
+    UserDetails userDetails = createUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-        testUser, null, testUser.getRoles());
+        userDetails, null, userDetails.getAuthorities());
 
     // 스레드 생성
     ThreadCreateRequest createRequest = ThreadCreateRequest.builder()
@@ -273,8 +326,9 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
   @DisplayName("다른 사용자의 스레드 수정 시도 - 실패")
   void updateOtherUserThread_Forbidden() throws Exception {
     // given - testUser가 스레드 생성
+    UserDetails testUserDetails = createUserDetails(testUser);
     UsernamePasswordAuthenticationToken testUserAuth = new UsernamePasswordAuthenticationToken(
-        testUser, null, testUser.getRoles());
+        testUserDetails, null, testUserDetails.getAuthorities());
 
     ThreadCreateRequest createRequest = ThreadCreateRequest.builder()
         .content("다른 사용자 스레드 내용")
@@ -291,8 +345,9 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
     Long threadId = savedThread.getId();
 
     // when & then - otherUser가 수정 시도
+    UserDetails otherUserDetails = createUserDetails(otherUser);
     UsernamePasswordAuthenticationToken otherUserAuth = new UsernamePasswordAuthenticationToken(
-        otherUser, null, otherUser.getRoles());
+        otherUserDetails, null, otherUserDetails.getAuthorities());
 
     ThreadUpdateRequest updateRequest = ThreadUpdateRequest.builder()
         .content("악의적 수정")


### PR DESCRIPTION
# Pull Request

## 🎯 문제 정의 및 배경

### 🔗 관련 이슈

Fixes #62

### 📌 문제 설명

기존 Smart Doc 기반 API 문서화 시스템을 OpenAPI 3.0 (Swagger) 기반으로 마이그레이션하여 더 표준적이고 개발자 친화적인 API 문서화 환경을 구축해야 합니다.

### 🎭 문제 발생 배경

- Smart Doc + Swagger UI 조합으로 사용하게 되면 웹 API 문서 페이지 기능에 매끄럽게 설정하기 어려움
- OpenAPI 3.0은 업계 표준이며 Swagger UI를 통한 인터랙티브한 API 테스트 환경 제공
- 팀 개발 생산성 향상 및 API 문서의 일관성 확보 필요

---

## 🔍 원인 분석

### 🐛 근본 원인

- 기존 Smart Doc 기반 문서화 시스템의 제한적인 기능성
- 실시간 API 테스트 환경의 부재
  - 제한적이거나 설정하기에 더 큰 시간비용을 소모

### 🔬 디버깅 과정

1. Smart Doc 설정 및 사용 현황 분석
2. OpenAPI 3.0 마이그레이션 요구사항 정의
3. 기존 API 엔드포인트 문서화 상태 점검

### 💭 고려했던 가능성들

- Smart Doc 업그레이드를 통한 기능 개선
- 다른 문서화 도구 (Spring REST Docs) 검토
- OpenAPI 3.0 완전 마이그레이션

---

## 💡 해결 방안

### 🤔 검토한 해결 방법들

#### 방법 1: Smart Doc 유지 + 기능 개선

- **장점**: 기존 설정 유지, 마이그레이션 비용 최소화
- **단점**: 표준성 부족, 제한적인 기능, 장기적 유지보수 어려움

#### 방법 2: OpenAPI 3.0 완전 마이그레이션

- **장점**: 업계 표준, 풍부한 기능, 인터랙티브 테스트 환경
- **단점**: 초기 마이그레이션 작업 필요

### ✅ 선택한 방법과 이유

**OpenAPI 3.0 완전 마이그레이션**을 선택했습니다.
- 장기적인 유지보수성과 확장성을 고려
- Swagger UI를 통한 개발자 경험 개선
- 업계 표준 준수로 인한 호환성 확보

---

## 📊 결과 및 영향

### 🚀 개선 사항

- Swagger UI를 통한 실시간 API 테스트 환경 제공
- 표준화된 OpenAPI 3.0 스펙 기반 문서화
- JWT 인증 통합 테스트 환경 구축
- 모든 API 엔드포인트에 대한 상세한 문서화

### ⚠️ 주의 사항

- 기존 Smart Doc 설정 완전 제거로 인한 롤백 불가
- 새로운 문서화 방식에 대한 팀 적응 기간 필요

### 📈 성능 영향

- 빌드 시간 단축 (Smart Doc 플러그인 제거)
- 런타임 성능에는 영향 없음 (정적 문서 생성)

---

## 📝 구현 세부사항

### 📁 주요 변경 내용

1. **Smart Doc 완전 제거**
   - build.gradle.kts에서 Smart Doc 플러그인 제거
   - smart-doc.json 설정 파일 삭제

2. **OpenAPI 3.0 설정 추가**
   - OpenApiConfig 클래스 생성
   - Swagger UI 경로 보안 설정

3. **API 문서화 인터페이스 패턴 도입**
   - 각 컨트롤러별 문서화 인터페이스 생성
   - @Operation, @ApiResponse 어노테이션 활용

4. **DTO 스키마 문서화**
   - @Schema 어노테이션으로 상세 문서화
   - 입력 검증 어노테이션 추가

---

## 🔧 기술적 변경 사항

### 📁 주요 변경 파일

- `build.gradle.kts` - Smart Doc 플러그인 제거
- `src/main/java/org/nodystudio/nodybackend/config/OpenApiConfig.java` - OpenAPI 설정
- `src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java` - Swagger UI 경로 허용
- `src/main/java/org/nodystudio/nodybackend/controller/**/docs/*.java` - API 문서화 인터페이스
- `src/main/java/org/nodystudio/nodybackend/controller/**/*Controller.java` - 문서화 인터페이스 구현
- `src/main/java/org/nodystudio/nodybackend/dto/*.java` - DTO 스키마 문서화
- `src/test/**/*.java` - 테스트 코드 업데이트

### 🛠️ API 변경 사항

기존 API 엔드포인트의 변경은 없으며, 문서화 방식만 변경되었습니다.

#### Swagger UI 접근 경로

```http
GET /swagger-ui.html
GET /swagger-ui/index.html
GET /v3/api-docs
```

### 🗄️ 데이터베이스 변경 사항

- [x] 데이터베이스 변경 없음

### 🔐 보안 관련 변경

- [x] CORS 설정 수정 (Swagger UI 경로 허용)
- [x] JWT 토큰 처리 수정 (OpenAPI 스키마 정의)

---

## ✅ 체크리스트

### 📋 코드 품질

- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 주석과 콘솔 로그를 제거했습니다
- [x] 적절한 예외 처리를 구현했습니다
- [x] API 응답 형식이 일관성 있게 구현되었습니다 (`ApiResponse<T>` 사용)

### 🧪 테스트

- [x] 새로운 기능에 대한 단위 테스트를 작성했습니다
- [x] API 테스트 케이스를 추가했습니다

### 📖 문서화

- [x] API 문서가 업데이트되었습니다 (Swagger/OpenAPI)
- [x] 코드 주석이 적절히 작성되었습니다
- [x] 변경 사항에 대한 문서를 작성했습니다

### 🔧 설정 및 환경

- [x] 개발 환경에서 정상 동작을 확인했습니다
- [x] 프로덕션 환경 설정을 고려했습니다
- [x] 환경별 설정 파일이 적절히 구성되었습니다 (dev, prod)
- [x] 의존성 추가 시 버전 충돌을 확인했습니다

---

## 🧪 테스트 결과

### 🔍 테스트 시나리오

1. Swagger UI 접근 및 API 문서 렌더링 확인
2. JWT 인증을 통한 보호된 API 엔드포인트 테스트
3. 모든 컨트롤러 API 문서화 상태 검증
4. 기존 단위 테스트 및 통합 테스트 통과 확인

### 📊 테스트 커버리지

- [x] 단위 테스트 커버리지: 기존 수준 유지
- [x] 통합 테스트 완료

---

## 📸 스크린샷 / 로그

Swagger UI 접근 경로: `http://localhost:8080/swagger-ui.html`

주요 기능:
- 모든 API 엔드포인트 문서화 완료
- JWT 인증 테스트 환경 구축
- 실시간 API 테스트 기능 제공

---

## 🚀 배포 시 주의사항

1. **의존성 확인**: springdoc-openapi-starter-webmvc-ui 라이브러리가 정상적으로 포함되었는지 확인
2. **보안 설정**: 운영 환경에서 Swagger UI 접근 권한 재검토 필요
3. **캐시 클리어**: 브라우저 캐시 클리어 후 새로운 Swagger UI 접근 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * OpenAPI 3.0 기반의 API 문서 자동화 및 보안 스키마(JWT Bearer) 설정이 추가되었습니다.
  * 관리자, 인증, 로그, 스레드, 사용자 등 주요 API에 Swagger/OpenAPI 기반의 문서화가 적용되었습니다.

* **기능 개선**
  * 관리자, 인증, 로그, 스레드, 사용자 컨트롤러의 메서드 시그니처가 일관성 있게 정비되고, 인증 정보 처리 방식이 표준(Spring Security UserDetails)으로 통일되었습니다.
  * 페이지네이션 및 정렬 파라미터 처리가 간소화되고, 일부 엔드포인트의 응답 구조가 단순화되었습니다.
  * API 응답 DTO에 Swagger 문서화 및 유효성 검증 어노테이션이 추가되었습니다.

* **버그 수정**
  * 인증 및 사용자 정보 처리에서 발생할 수 있는 오류를 방지하기 위해 파라미터 타입과 인증 흐름이 개선되었습니다.

* **문서화**
  * 모든 주요 API 엔드포인트에 대한 Swagger/OpenAPI 문서가 추가되어, 개발자 및 사용자 대상의 자동화된 API 문서 제공이 가능해졌습니다.

* **테스트**
  * 컨트롤러 및 통합 테스트 코드가 새로운 인증 방식과 파라미터 구조에 맞게 리팩터링되었습니다.

* **정리 및 기타**
  * smart-doc 플러그인 및 관련 설정 파일이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->