### PR TITLE
feat(security): CustomUserDetails 구현체 추가 및 통합

### DIFF
--- a/src/main/java/org/nodystudio/nodybackend/controller/log/LogController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/log/LogController.java
@@ -10,6 +10,7 @@ import org.nodystudio.nodybackend.dto.log.LogResponse;
 import org.nodystudio.nodybackend.dto.log.LogSearchRequest;
 import org.nodystudio.nodybackend.dto.log.LogUpdateRequest;
 import org.nodystudio.nodybackend.dto.thread.ThreadResponse;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.nodystudio.nodybackend.service.log.LogService;
 import org.nodystudio.nodybackend.service.thread.ThreadService;
 import org.springframework.data.domain.Page;
@@ -18,7 +19,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -45,12 +45,12 @@ public class LogController implements LogApiDocs {
   @Override
   @PostMapping
   public ResponseEntity<ApiResponse<LogResponse>> createLog(
-      @AuthenticationPrincipal UserDetails userDetails,
+      @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody LogCreateRequest request) {
 
-    log.info("로그 생성 요청 - 사용자: {}", userDetails.getUsername());
+    log.info("로그 생성 요청 - 사용자: {}", userDetails.getUser().getId());
 
-    LogResponse response = logService.createLog(request, userDetails.getUsername());
+    LogResponse response = logService.createLog(request, userDetails.getEmail());
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResponse.success("로그가 성공적으로 생성되었습니다.", response));
@@ -63,13 +63,13 @@ public class LogController implements LogApiDocs {
   @GetMapping("/{id}")
   public ResponseEntity<ApiResponse<LogResponse>> getLog(
       @PathVariable Long id) {
-    UserDetails userDetails = null;
+    CustomUserDetails userDetails = null;
 
     log.info("로그 단건 조회 - ID: {}, 사용자: {}", id,
-        userDetails != null ? userDetails.getUsername() : "익명");
+        userDetails != null ? userDetails.getUser().getId() : "익명");
 
     LogResponse response = logService.getLog(id,
-        userDetails != null ? userDetails.getUsername() : null);
+        userDetails != null ? userDetails.getEmail() : null);
 
     return ResponseEntity.ok(ApiResponse.success("로그 조회가 완료되었습니다.", response));
   }
@@ -82,15 +82,15 @@ public class LogController implements LogApiDocs {
   public ResponseEntity<ApiResponse<Page<LogResponse>>> getLogs(
       @Valid @ModelAttribute LogSearchRequest searchRequest,
       @PageableDefault(size = 20) Pageable pageable) {
-    UserDetails userDetails = null;
+    CustomUserDetails userDetails = null;
 
     log.info("로그 목록 조회 - 위치: ({}, {}), 반경: {}km, 사용자: {}",
         searchRequest.getLatitude(), searchRequest.getLongitude(),
         searchRequest.getRadiusKm(),
-        userDetails != null ? userDetails.getUsername() : "익명");
+        userDetails != null ? userDetails.getUser().getId() : "익명");
 
     Page<LogResponse> response = logService.searchLogs(searchRequest,
-        userDetails != null ? userDetails.getUsername() : null);
+        userDetails != null ? userDetails.getEmail() : null);
 
     return ResponseEntity.ok(ApiResponse.success("로그 목록 조회가 완료되었습니다.", response));
   }
@@ -102,12 +102,12 @@ public class LogController implements LogApiDocs {
   @PutMapping("/{id}")
   public ResponseEntity<ApiResponse<LogResponse>> updateLog(
       @PathVariable Long id,
-      @AuthenticationPrincipal UserDetails userDetails,
+      @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody LogUpdateRequest request) {
 
-    log.info("로그 수정 요청 - ID: {}, 사용자: {}", id, userDetails.getUsername());
+    log.info("로그 수정 요청 - ID: {}, 사용자: {}", id, userDetails.getUser().getId());
 
-    LogResponse response = logService.updateLog(id, request, userDetails.getUsername());
+    LogResponse response = logService.updateLog(id, request, userDetails.getEmail());
 
     return ResponseEntity.ok(ApiResponse.success("로그가 성공적으로 수정되었습니다.", response));
   }
@@ -119,11 +119,11 @@ public class LogController implements LogApiDocs {
   @DeleteMapping("/{id}")
   public ResponseEntity<ApiResponse<Void>> deleteLog(
       @PathVariable Long id,
-      @AuthenticationPrincipal UserDetails userDetails) {
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-    log.info("로그 삭제 요청 - ID: {}, 사용자: {}", id, userDetails.getUsername());
+    log.info("로그 삭제 요청 - ID: {}, 사용자: {}", id, userDetails.getUser().getId());
 
-    logService.deleteLog(id, userDetails.getUsername());
+    logService.deleteLog(id, userDetails.getEmail());
 
     return ResponseEntity.ok(ApiResponse.success("로그가 성공적으로 삭제되었습니다.", null));
   }
@@ -137,12 +137,12 @@ public class LogController implements LogApiDocs {
       @PathVariable Long logId,
       @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
 
-    UserDetails userDetails = null;
+    CustomUserDetails userDetails = null;
     log.info("로그 스레드 목록 조회 - 로그ID: {}, 사용자: {}",
-        logId, userDetails != null ? userDetails.getUsername() : "익명");
+        logId, userDetails != null ? userDetails.getUser().getId() : "익명");
 
     Page<ThreadResponse> response = threadService.getThreadsByLog(logId,
-        userDetails != null ? userDetails.getUsername() : null, pageable);
+        userDetails != null ? userDetails.getEmail() : null, pageable);
 
     return ResponseEntity.ok(ApiResponse.success("로그 스레드 목록 조회가 완료되었습니다.", response));
   }

--- a/src/main/java/org/nodystudio/nodybackend/controller/log/docs/LogApiDocs.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/log/docs/LogApiDocs.java
@@ -14,12 +14,12 @@ import org.nodystudio.nodybackend.dto.log.LogResponse;
 import org.nodystudio.nodybackend.dto.log.LogSearchRequest;
 import org.nodystudio.nodybackend.dto.log.LogUpdateRequest;
 import org.nodystudio.nodybackend.dto.thread.ThreadResponse;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -59,7 +59,7 @@ public interface LogApiDocs {
       )
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<LogResponse>> createLog(
-      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+      @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody LogCreateRequest request
   );
 
@@ -147,7 +147,7 @@ public interface LogApiDocs {
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<LogResponse>> updateLog(
       @Parameter(description = "로그 ID") @PathVariable Long id,
-      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+      @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody LogUpdateRequest request
   );
 
@@ -180,7 +180,7 @@ public interface LogApiDocs {
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Void>> deleteLog(
       @Parameter(description = "로그 ID") @PathVariable Long id,
-      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails
+      @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
   );
 
   @Operation(

--- a/src/main/java/org/nodystudio/nodybackend/controller/thread/ThreadController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/thread/ThreadController.java
@@ -12,6 +12,7 @@ import org.nodystudio.nodybackend.dto.thread.ThreadCreateRequest;
 import org.nodystudio.nodybackend.dto.thread.ThreadResponse;
 import org.nodystudio.nodybackend.dto.thread.ThreadSearchRequest;
 import org.nodystudio.nodybackend.dto.thread.ThreadUpdateRequest;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.nodystudio.nodybackend.service.thread.ThreadService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -43,8 +44,8 @@ public class ThreadController implements ThreadApiDocs {
   /**
    * 로그에 표시할 사용자 정보를 안전하게 가져옵니다. 인증되지 않은 사용자의 경우 "익명"을 반환합니다.
    */
-  private String getUserDisplayName(UserDetails userDetails) {
-    return userDetails != null ? userDetails.getUsername() : "익명";
+  private String getUserDisplayName(CustomUserDetails userDetails) {
+    return userDetails != null ? userDetails.getEmail() : "익명";
   }
 
   /**
@@ -77,13 +78,13 @@ public class ThreadController implements ThreadApiDocs {
   @Override
   @PostMapping
   public ResponseEntity<ApiResponse<ThreadResponse>> createThread(
-      @AuthenticationPrincipal UserDetails userDetails,
+      @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody ThreadCreateRequest request) {
 
     log.info("스레드 생성 요청 - 사용자: {}",
         getUserDisplayName(userDetails));
 
-    ThreadResponse response = threadService.createThread(request, userDetails.getUsername());
+    ThreadResponse response = threadService.createThread(request, userDetails.getEmail());
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResponse.success("스레드가 성공적으로 생성되었습니다.", response));
@@ -96,13 +97,13 @@ public class ThreadController implements ThreadApiDocs {
   @GetMapping("/{id}")
   public ResponseEntity<ApiResponse<ThreadResponse>> getThread(
       @PathVariable Long id) {
-    UserDetails userDetails = null;
+    CustomUserDetails userDetails = null;
 
     log.info("스레드 단건 조회 - ID: {}, 사용자: {}",
         id, getUserDisplayName(userDetails));
 
     ThreadResponse response = threadService.getThread(
-        id, userDetails != null ? userDetails.getUsername() : null);
+        id, userDetails != null ? userDetails.getEmail() : null);
 
     return ResponseEntity.ok(ApiResponse.success("스레드 조회가 완료되었습니다.", response));
   }
@@ -115,7 +116,7 @@ public class ThreadController implements ThreadApiDocs {
   public ResponseEntity<ApiResponse<Page<ThreadResponse>>> getThreads(
       @Valid @ModelAttribute ThreadSearchRequest searchRequest,
       @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
-    UserDetails userDetails = null;
+    CustomUserDetails userDetails = null;
 
     log.info("스레드 목록 조회 - 키워드: {}, 타입: {}, 로그ID: {}, 사용자: {}",
         searchRequest.getKeyword(),
@@ -124,7 +125,7 @@ public class ThreadController implements ThreadApiDocs {
         getUserDisplayName(userDetails));
 
     Page<ThreadResponse> response = threadService.searchThreads(searchRequest,
-        userDetails != null ? userDetails.getUsername() : null);
+        userDetails != null ? userDetails.getEmail() : null);
 
     return ResponseEntity.ok(ApiResponse.success("스레드 목록 조회가 완료되었습니다.", response));
   }
@@ -136,12 +137,12 @@ public class ThreadController implements ThreadApiDocs {
   @PutMapping("/{id}")
   public ResponseEntity<ApiResponse<ThreadResponse>> updateThread(
       @PathVariable Long id,
-      @AuthenticationPrincipal UserDetails userDetails,
+      @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody ThreadUpdateRequest request) {
 
     log.info("스레드 수정 요청 - ID: {}, 사용자: {}", id, getUserDisplayName(userDetails));
 
-    ThreadResponse response = threadService.updateThread(id, request, userDetails.getUsername());
+    ThreadResponse response = threadService.updateThread(id, request, userDetails.getEmail());
 
     return ResponseEntity.ok(ApiResponse.success("스레드가 성공적으로 수정되었습니다.", response));
   }
@@ -153,11 +154,11 @@ public class ThreadController implements ThreadApiDocs {
   @DeleteMapping("/{id}")
   public ResponseEntity<ApiResponse<Void>> deleteThread(
       @PathVariable Long id,
-      @AuthenticationPrincipal UserDetails userDetails) {
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
 
     log.info("스레드 삭제 요청 - ID: {}, 사용자: {}", id, getUserDisplayName(userDetails));
 
-    threadService.deleteThread(id, userDetails.getUsername());
+    threadService.deleteThread(id, userDetails.getEmail());
 
     return ResponseEntity.ok(ApiResponse.success("스레드가 성공적으로 삭제되었습니다.", null));
   }
@@ -170,7 +171,7 @@ public class ThreadController implements ThreadApiDocs {
   @GetMapping("/independent")
   public ResponseEntity<ApiResponse<Page<ThreadResponse>>> getIndependentThreads(
       @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
-    UserDetails userDetails = null;
+    CustomUserDetails userDetails = null;
     String keyword = null;
 
     log.info("독립 스레드 목록 조회 - 키워드: {}, 사용자: {}", keyword,
@@ -180,7 +181,7 @@ public class ThreadController implements ThreadApiDocs {
         ThreadType.INDEPENDENT);
 
     Page<ThreadResponse> response = threadService.searchThreads(searchRequest,
-        userDetails != null ? userDetails.getUsername() : null);
+        userDetails != null ? userDetails.getEmail() : null);
 
     return ResponseEntity.ok(ApiResponse.success("독립 스레드 목록 조회가 완료되었습니다.", response));
   }
@@ -192,7 +193,7 @@ public class ThreadController implements ThreadApiDocs {
   @GetMapping("/linked")
   public ResponseEntity<ApiResponse<Page<ThreadResponse>>> getLinkedThreads(
       @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
-    UserDetails userDetails = null;
+    CustomUserDetails userDetails = null;
     String keyword = null;
 
     log.info("로그 연결 스레드 목록 조회 - 키워드: {}, 사용자: {}", keyword,
@@ -202,7 +203,7 @@ public class ThreadController implements ThreadApiDocs {
         ThreadType.LINKED);
 
     Page<ThreadResponse> response = threadService.searchThreads(searchRequest,
-        userDetails != null ? userDetails.getUsername() : null);
+        userDetails != null ? userDetails.getEmail() : null);
 
     return ResponseEntity.ok(ApiResponse.success("로그 연결 스레드 목록 조회가 완료되었습니다.", response));
   }

--- a/src/main/java/org/nodystudio/nodybackend/controller/thread/docs/ThreadApiDocs.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/thread/docs/ThreadApiDocs.java
@@ -13,6 +13,7 @@ import org.nodystudio.nodybackend.dto.thread.ThreadCreateRequest;
 import org.nodystudio.nodybackend.dto.thread.ThreadResponse;
 import org.nodystudio.nodybackend.dto.thread.ThreadSearchRequest;
 import org.nodystudio.nodybackend.dto.thread.ThreadUpdateRequest;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -58,7 +59,7 @@ public interface ThreadApiDocs {
       )
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<ThreadResponse>> createThread(
-      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+      @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody ThreadCreateRequest request
   );
 
@@ -146,7 +147,7 @@ public interface ThreadApiDocs {
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<ThreadResponse>> updateThread(
       @Parameter(description = "스레드 ID") @PathVariable Long id,
-      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+      @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody ThreadUpdateRequest request
   );
 
@@ -179,7 +180,7 @@ public interface ThreadApiDocs {
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Void>> deleteThread(
       @Parameter(description = "스레드 ID") @PathVariable Long id,
-      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails
+      @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
   );
 
   @Operation(

--- a/src/main/java/org/nodystudio/nodybackend/controller/user/UserController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/user/UserController.java
@@ -3,11 +3,11 @@ package org.nodystudio.nodybackend.controller.user;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.nodystudio.nodybackend.controller.user.docs.UserApiDocs;
-import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.dto.ApiResponse;
 import org.nodystudio.nodybackend.dto.code.SuccessCode;
 import org.nodystudio.nodybackend.dto.user.UpdateNicknameRequestDto;
 import org.nodystudio.nodybackend.dto.user.UserDetailResponseDto;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.nodystudio.nodybackend.service.user.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -33,18 +33,17 @@ public class UserController implements UserApiDocs {
    *
    * <p>
    * 이 엔드포인트는 Spring Security에 의해 관리되며, 인증된 사용자만 접근할 수 있습니다. {@code @AuthenticationPrincipal}을 통해
-   * 주입되는 user 객체는 Spring Security가 이미 검증했으므로 별도의 null 체크가 불필요합니다.
+   * 주입되는 userDetails 객체는 Spring Security가 이미 검증했으므로 별도의 null 체크가 불필요합니다.
    * </p>
    *
-   * @param user 인증된 사용자 정보 (Spring Security에 의해 보장됨)
+   * @param userDetails 인증된 사용자 정보 (Spring Security에 의해 보장됨)
    * @return UserDetailResponseDto 사용자 정보
    */
   @Override
   @GetMapping(value = "/me")
   public ResponseEntity<ApiResponse<UserDetailResponseDto>> getCurrentUser(
-      @AuthenticationPrincipal Object user) {
-    User currentUser = (User) user;
-    UserDetailResponseDto userDetail = userService.getCurrentUser(currentUser.getId().toString());
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    UserDetailResponseDto userDetail = userService.getCurrentUser(userDetails.getUser().getId().toString());
 
     return ResponseEntity
         .status(SuccessCode.OK.getStatus())
@@ -54,17 +53,16 @@ public class UserController implements UserApiDocs {
   /**
    * 사용자의 닉네임을 변경
    *
-   * @param user       인증된 사용자 정보 (@ignore)
+   * @param userDetails 인증된 사용자 정보 (@ignore)
    * @param requestDto 닉네임 변경 요청 DTO
    * @return UserDetailResponseDto 변경된 사용자 정보
    */
   @Override
   @PutMapping(value = "/nickname")
   public ResponseEntity<ApiResponse<UserDetailResponseDto>> updateNickname(
-      @AuthenticationPrincipal Object user,
+      @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody UpdateNicknameRequestDto requestDto) {
-    User currentUser = (User) user;
-    UserDetailResponseDto updatedUser = userService.updateNickname(currentUser.getId().toString(),
+    UserDetailResponseDto updatedUser = userService.updateNickname(userDetails.getUser().getId().toString(),
         requestDto);
 
     return ResponseEntity
@@ -75,15 +73,14 @@ public class UserController implements UserApiDocs {
   /**
    * 사용자 계정을 탈퇴합니다 - 즉시 계정 비활성화 및 사용자 데이터 삭제 - 30일 후 완전 삭제 (배치 처리)
    *
-   * @param user 인증된 사용자 정보 (@ignore)
+   * @param userDetails 인증된 사용자 정보 (@ignore)
    * @return 탈퇴 처리 결과
    */
   @Override
   @DeleteMapping(value = "/me")
   public ResponseEntity<ApiResponse<Void>> deactivateAccount(
-      @AuthenticationPrincipal Object user) {
-    User currentUser = (User) user;
-    userService.deactivateAccount(currentUser.getId().toString());
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    userService.deactivateAccount(userDetails.getUser().getId().toString());
 
     return ResponseEntity
         .status(SuccessCode.OK.getStatus())

--- a/src/main/java/org/nodystudio/nodybackend/controller/user/docs/UserApiDocs.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/user/docs/UserApiDocs.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.nodystudio.nodybackend.dto.user.UpdateNicknameRequestDto;
 import org.nodystudio.nodybackend.dto.user.UserDetailResponseDto;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,7 +43,7 @@ public interface UserApiDocs {
       )
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<UserDetailResponseDto>> getCurrentUser(
-      @Parameter(hidden = true) @AuthenticationPrincipal Object currentUser
+      @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails currentUser
   );
 
   @Operation(
@@ -81,7 +82,7 @@ public interface UserApiDocs {
       )
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<UserDetailResponseDto>> updateNickname(
-      @Parameter(hidden = true) @AuthenticationPrincipal Object currentUser,
+      @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails currentUser,
       @Valid @RequestBody UpdateNicknameRequestDto requestDto
   );
 
@@ -105,6 +106,6 @@ public interface UserApiDocs {
       )
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Void>> deactivateAccount(
-      @Parameter(hidden = true) @AuthenticationPrincipal Object currentUser
+      @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails currentUser
   );
 }

--- a/src/main/java/org/nodystudio/nodybackend/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/nodystudio/nodybackend/security/filter/JwtAuthenticationFilter.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.repository.UserRepository;
 import org.nodystudio.nodybackend.security.jwt.TokenProvider;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.nodystudio.nodybackend.util.LoggingUtils;
 import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -18,7 +19,6 @@ import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
@@ -140,9 +140,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return new DisabledException("비활성화되었거나 존재하지 않는 사용자 계정입니다");
           });
 
-      List<GrantedAuthority> authorities = user.getRoles();
-
-      return new UsernamePasswordAuthenticationToken(user, null, authorities);
+      CustomUserDetails userDetails = new CustomUserDetails(user);
+      
+      return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     } catch (DisabledException e) {
       throw e;
     } catch (Exception e) {

--- a/src/main/java/org/nodystudio/nodybackend/security/userdetails/CustomUserDetails.java
+++ b/src/main/java/org/nodystudio/nodybackend/security/userdetails/CustomUserDetails.java
@@ -1,0 +1,113 @@
+package org.nodystudio.nodybackend.security.userdetails;
+
+import java.util.Collection;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.nodystudio.nodybackend.domain.enums.OAuthProvider;
+import org.nodystudio.nodybackend.domain.user.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+/**
+ * Spring Security의 인증 주체로 사용되는 커스텀 UserDetails 구현체입니다.
+ *
+ * <p>
+ * 이 클래스는 {@link User} 엔티티를 래핑하여 Spring Security가 요구하는
+ * {@link UserDetails} 인터페이스를 구현합니다. JWT 기반 인증 시스템에서
+ * 인증된 사용자 정보를 보안 컨텍스트에 저장하는 데 사용됩니다.
+ * </p>
+ *
+ * @see UserDetails
+ * @see User
+ */
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * 래핑된 User 엔티티
+   */
+  private final User user;
+
+  /**
+   * 사용자의 권한 목록을 반환합니다.
+   *
+   * @return 사용자가 가진 권한 목록
+   */
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return user.getRoles();
+  }
+
+  public String getEmail() { return user.getEmail(); }
+
+  public String getNickname() { return user.getNickname(); }
+
+  public OAuthProvider getProvider() { return user.getProvider(); }
+
+  /**
+   * 사용자의 비밀번호를 반환합니다.
+   *
+   * <p>
+   * OAuth2 기반 인증 시스템이므로 비밀번호는 사용하지 않습니다.
+   * </p>
+   *
+   * @return null (OAuth2 인증 사용)
+   */
+  @Override
+  public String getPassword() {
+    return null;
+  }
+
+  /**
+   * 사용자의 고유 식별자를 반환합니다.
+   *
+   * @return 사용자 ID 문자열
+   */
+  @Override
+  public String getUsername() {
+    return user.getId().toString();
+  }
+
+  /**
+   * 계정 만료 여부를 반환합니다.
+   *
+   * @return true (계정 만료 기능 미사용)
+   */
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  /**
+   * 계정 잠금 여부를 반환합니다.
+   *
+   * @return 사용자 활성화 상태
+   */
+  @Override
+  public boolean isAccountNonLocked() {
+    return user.getIsActive();
+  }
+
+  /**
+   * 자격 증명 만료 여부를 반환합니다.
+   *
+   * @return true (자격 증명 만료 기능 미사용)
+   */
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  /**
+   * 계정 활성화 여부를 반환합니다.
+   *
+   * @return 사용자 활성화 상태
+   */
+  @Override
+  public boolean isEnabled() {
+    return user.getIsActive();
+  }
+}

--- a/src/test/java/org/nodystudio/nodybackend/controller/log/LogControllerTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/controller/log/LogControllerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -33,13 +34,14 @@ import org.nodystudio.nodybackend.dto.log.LogUpdateRequest;
 import org.nodystudio.nodybackend.dto.thread.ThreadResponse;
 import org.nodystudio.nodybackend.dto.user.UserSummaryResponse;
 import org.nodystudio.nodybackend.service.log.LogService;
+import org.nodystudio.nodybackend.domain.user.User;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.nodystudio.nodybackend.service.thread.ThreadService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.userdetails.UserDetails;
 
 /**
  * - 로그 CRUD 기능 테스트 - 위치 기반 검색 테스트 - 권한 검증 테스트 - 공개/비공개 필터링 테스트
@@ -58,13 +60,16 @@ class LogControllerTest {
   private LogController logController;
 
   private LogResponse testLogResponse;
-  private UserDetails mockUserDetails;
+  private CustomUserDetails mockUserDetails;
 
   @BeforeEach
   void setUp() {
-    // Mock UserDetails 생성 (lenient를 사용하여 불필요한 stubbing 경고 방지)
-    mockUserDetails = org.mockito.Mockito.mock(UserDetails.class);
-    lenient().when(mockUserDetails.getUsername()).thenReturn("test@example.com");
+    // Mock User와 CustomUserDetails 생성
+    User mockUser = mock(User.class);
+    lenient().when(mockUser.getId()).thenReturn(1L);
+    lenient().when(mockUser.getEmail()).thenReturn("test@example.com");
+    
+    mockUserDetails = new CustomUserDetails(mockUser);
 
     UserSummaryResponse author = UserSummaryResponse.builder()
         .id(1L)

--- a/src/test/java/org/nodystudio/nodybackend/controller/thread/ThreadControllerTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/controller/thread/ThreadControllerTest.java
@@ -9,6 +9,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import jakarta.validation.ConstraintViolation;
@@ -26,10 +28,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.GrantedAuthority;
+import org.nodystudio.nodybackend.domain.user.User;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import java.util.Collection;
 import java.util.List;
 import org.nodystudio.nodybackend.dto.ApiResponse;
 import org.nodystudio.nodybackend.dto.code.ErrorCode;
@@ -55,7 +56,6 @@ class ThreadControllerTest {
   private ThreadController threadController;
 
   private ThreadResponse threadResponse;
-  private UserDetails mockUserDetails;
   private Validator validator;
 
   @BeforeEach
@@ -64,44 +64,6 @@ class ThreadControllerTest {
     try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
       validator = factory.getValidator();
     }
-
-    // Mock UserDetails 생성
-    mockUserDetails = new UserDetails() {
-      @Override
-      public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
-      }
-
-      @Override
-      public String getPassword() {
-        return null;
-      }
-
-      @Override
-      public String getUsername() {
-        return "test@example.com";
-      }
-
-      @Override
-      public boolean isAccountNonExpired() {
-        return true;
-      }
-
-      @Override
-      public boolean isAccountNonLocked() {
-        return true;
-      }
-
-      @Override
-      public boolean isCredentialsNonExpired() {
-        return true;
-      }
-
-      @Override
-      public boolean isEnabled() {
-        return true;
-      }
-    };
 
     UserSummaryResponse userResponse = UserSummaryResponse.builder()
         .id(1L)
@@ -120,6 +82,21 @@ class ThreadControllerTest {
         .isLinkedToLog(false)
         .isIndependent(true)
         .build();
+  }
+
+  /**
+   * 테스트용 CustomUserDetails 객체를 생성합니다.
+   *
+   * @return 설정된 CustomUserDetails 객체
+   */
+  private CustomUserDetails createMockUserDetails() {
+    User mockUser = mock(User.class);
+    lenient().when(mockUser.getId()).thenReturn(1L);
+    lenient().when(mockUser.getEmail()).thenReturn("test@example.com");
+    lenient().when(mockUser.getRoles()).thenReturn(List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    lenient().when(mockUser.getIsActive()).thenReturn(true);
+
+    return new CustomUserDetails(mockUser);
   }
 
   @Test
@@ -151,8 +128,9 @@ class ThreadControllerTest {
         .willReturn(createResponse);
 
     // when
+    CustomUserDetails userDetails = createMockUserDetails();
     ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.createThread(
-        mockUserDetails, request);
+        userDetails, request);
 
     // then
     assertEquals(201, response.getStatusCode().value());
@@ -213,7 +191,8 @@ class ThreadControllerTest {
     willDoNothing().given(threadService).deleteThread(1L, "test@example.com");
 
     // when
-    ResponseEntity<ApiResponse<Void>> response = threadController.deleteThread(1L, mockUserDetails);
+    CustomUserDetails userDetails = createMockUserDetails();
+    ResponseEntity<ApiResponse<Void>> response = threadController.deleteThread(1L, userDetails);
 
     // then
     assertEquals(200, response.getStatusCode().value());

--- a/src/test/java/org/nodystudio/nodybackend/integration/ThreadIntegrationTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/integration/ThreadIntegrationTest.java
@@ -29,12 +29,13 @@ import org.nodystudio.nodybackend.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
 import java.util.Collection;
 import java.util.List;
+
 
 @DisplayName("Thread 통합 테스트")
 class ThreadIntegrationTest extends BaseIntegrationTest {
@@ -91,52 +92,18 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * User 객체를 UserDetails로 변환하는 헬퍼 메서드
+   * User 객체를 CustomUserDetails로 변환하는 헬퍼 메서드
    */
-  private UserDetails createUserDetails(User user) {
-    return new UserDetails() {
-      @Override
-      public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
-      }
-
-      @Override
-      public String getPassword() {
-        return null;
-      }
-
-      @Override
-      public String getUsername() {
-        return user.getEmail();
-      }
-
-      @Override
-      public boolean isAccountNonExpired() {
-        return true;
-      }
-
-      @Override
-      public boolean isAccountNonLocked() {
-        return true;
-      }
-
-      @Override
-      public boolean isCredentialsNonExpired() {
-        return true;
-      }
-
-      @Override
-      public boolean isEnabled() {
-        return user.getIsActive();
-      }
-    };
+  private CustomUserDetails createUserDetails(User user) {
+    // 실제 DB User 객체를 CustomUserDetails에 전달
+    return new CustomUserDetails(user);
   }
 
   @Test
   @DisplayName("독립 스레드 생성 성공")
   void createIndependentThread_Success() throws Exception {
     // given
-    UserDetails userDetails = createUserDetails(testUser);
+    CustomUserDetails userDetails = createUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
         userDetails, null, userDetails.getAuthorities());
 
@@ -162,7 +129,7 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
   @DisplayName("로그 연결 스레드 생성 성공")
   void createLogLinkedThread_Success() throws Exception {
     // given
-    UserDetails userDetails = createUserDetails(testUser);
+    CustomUserDetails userDetails = createUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
         userDetails, null, userDetails.getAuthorities());
 
@@ -189,7 +156,7 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
   @DisplayName("스레드 단건 조회 성공")
   void getThread_Success() throws Exception {
     // given
-    UserDetails userDetails = createUserDetails(testUser);
+    CustomUserDetails userDetails = createUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
         userDetails, null, userDetails.getAuthorities());
 
@@ -222,7 +189,7 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
   @DisplayName("인증 없이 공개 스레드 조회 성공")
   void getPublicThread_WithoutAuth_Success() throws Exception {
     // given - 공개 스레드 생성
-    UserDetails userDetails = createUserDetails(testUser);
+    CustomUserDetails userDetails = createUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
         userDetails, null, userDetails.getAuthorities());
 
@@ -252,7 +219,7 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
   @DisplayName("스레드 수정 성공")
   void updateThread_Success() throws Exception {
     // given
-    UserDetails userDetails = createUserDetails(testUser);
+    CustomUserDetails userDetails = createUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
         userDetails, null, userDetails.getAuthorities());
 
@@ -293,7 +260,7 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
   @DisplayName("스레드 삭제 성공")
   void deleteThread_Success() throws Exception {
     // given
-    UserDetails userDetails = createUserDetails(testUser);
+    CustomUserDetails userDetails = createUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
         userDetails, null, userDetails.getAuthorities());
 
@@ -327,7 +294,7 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
   @DisplayName("다른 사용자의 스레드 수정 시도 - 실패")
   void updateOtherUserThread_Forbidden() throws Exception {
     // given - testUser가 스레드 생성
-    UserDetails testUserDetails = createUserDetails(testUser);
+    CustomUserDetails testUserDetails = createUserDetails(testUser);
     UsernamePasswordAuthenticationToken testUserAuth = new UsernamePasswordAuthenticationToken(
         testUserDetails, null, testUserDetails.getAuthorities());
 
@@ -346,7 +313,7 @@ class ThreadIntegrationTest extends BaseIntegrationTest {
     Long threadId = savedThread.getId();
 
     // when & then - otherUser가 수정 시도
-    UserDetails otherUserDetails = createUserDetails(otherUser);
+    CustomUserDetails otherUserDetails = createUserDetails(otherUser);
     UsernamePasswordAuthenticationToken otherUserAuth = new UsernamePasswordAuthenticationToken(
         otherUserDetails, null, otherUserDetails.getAuthorities());
 

--- a/src/test/java/org/nodystudio/nodybackend/integration/UserApiIntegrationTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/integration/UserApiIntegrationTest.java
@@ -19,6 +19,7 @@ import org.nodystudio.nodybackend.domain.user.RoleType;
 import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.dto.user.UpdateNicknameRequestDto;
 import org.nodystudio.nodybackend.repository.UserRepository;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -53,9 +54,10 @@ class UserApiIntegrationTest extends BaseIntegrationTest {
   @Test
   @DisplayName("현재 사용자 정보 조회 - 성공")
   void getCurrentUser_success() throws Exception {
+    CustomUserDetails userDetails = new CustomUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-        testUser, null,
-        testUser.getRoles());
+        userDetails, null,
+        userDetails.getAuthorities());
 
     mockMvc.perform(get("/api/user/me")
             .with(authentication(authentication))
@@ -83,9 +85,10 @@ class UserApiIntegrationTest extends BaseIntegrationTest {
     // given
     String newNickname = "새로운닉네임";
     UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto(newNickname);
+    CustomUserDetails userDetails = new CustomUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-        testUser, null,
-        testUser.getRoles());
+        userDetails, null,
+        userDetails.getAuthorities());
 
     // when & then
     mockMvc.perform(put("/api/user/nickname")
@@ -106,9 +109,10 @@ class UserApiIntegrationTest extends BaseIntegrationTest {
   void updateNickname_validationFail_blankNickname() throws Exception {
     // given
     UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("");
+    CustomUserDetails userDetails = new CustomUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-        testUser, null,
-        testUser.getRoles());
+        userDetails, null,
+        userDetails.getAuthorities());
 
     // when & then
     mockMvc.perform(put("/api/user/nickname")
@@ -139,9 +143,10 @@ class UserApiIntegrationTest extends BaseIntegrationTest {
   @DisplayName("계정 탈퇴 - 성공")
   void deactivateAccount_success() throws Exception {
     // given
+    CustomUserDetails userDetails = new CustomUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-        testUser, null,
-        testUser.getRoles());
+        userDetails, null,
+        userDetails.getAuthorities());
 
     // when & then
     mockMvc.perform(delete("/api/user/me")
@@ -176,9 +181,10 @@ class UserApiIntegrationTest extends BaseIntegrationTest {
     testUser.deactivateAccount();
     userRepository.save(testUser);
 
+    CustomUserDetails userDetails = new CustomUserDetails(testUser);
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-        testUser, null,
-        testUser.getRoles());
+        userDetails, null,
+        userDetails.getAuthorities());
 
     // when & then - 탈퇴한 계정으로는 API 접근 불가 (활성 사용자만 조회)
     mockMvc.perform(delete("/api/user/me")

--- a/src/test/java/org/nodystudio/nodybackend/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/security/filter/JwtAuthenticationFilterTest.java
@@ -26,6 +26,7 @@ import org.nodystudio.nodybackend.domain.user.RoleType;
 import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.repository.UserRepository;
 import org.nodystudio.nodybackend.security.jwt.TokenProvider;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
@@ -123,7 +124,9 @@ class JwtAuthenticationFilterTest {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     assertThat(authentication).isNotNull();
     assertThat(authentication.isAuthenticated()).isTrue();
-    assertThat(authentication.getPrincipal()).isEqualTo(mockUser);
+    assertThat(authentication.getPrincipal()).isInstanceOf(CustomUserDetails.class);
+    CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
+    assertThat(principal.getUser()).isEqualTo(mockUser);
     assertThat(authentication.getAuthorities()).extracting("authority")
         .containsExactly("ROLE_USER");
 

--- a/src/test/java/org/nodystudio/nodybackend/security/userdetails/CustomUserDetailsTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/security/userdetails/CustomUserDetailsTest.java
@@ -1,0 +1,214 @@
+package org.nodystudio.nodybackend.security.userdetails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.nodystudio.nodybackend.domain.enums.OAuthProvider;
+import org.nodystudio.nodybackend.domain.user.RoleType;
+import org.nodystudio.nodybackend.domain.user.User;
+import org.springframework.security.core.GrantedAuthority;
+
+/**
+ * CustomUserDetails 클래스의 단위 테스트
+ */
+@DisplayName("CustomUserDetails 단위 테스트")
+class CustomUserDetailsTest {
+
+  private User user;
+  private CustomUserDetails userDetails;
+
+  @BeforeEach
+  void setUp() {
+    user = User.builder()
+        .id(1L)
+        .provider(OAuthProvider.GOOGLE)
+        .socialId("google123")
+        .email("test@example.com")
+        .nickname("테스트유저")
+        .isActive(true)
+        .role(RoleType.USER)
+        .build();
+    
+    userDetails = new CustomUserDetails(user);
+  }
+
+  @Nested
+  @DisplayName("UserDetails 인터페이스 구현 테스트")
+  class UserDetailsImplementationTest {
+
+    @Test
+    @DisplayName("사용자 권한 목록을 올바르게 반환한다")
+    void getAuthorities_shouldReturnUserAuthorities() {
+      // when
+      Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
+
+      // then
+      assertThat(authorities)
+          .hasSize(1)
+          .extracting(GrantedAuthority::getAuthority)
+          .contains("ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("OAuth2 인증 사용으로 패스워드는 null을 반환한다")
+    void getPassword_shouldReturnNull() {
+      // when
+      String password = userDetails.getPassword();
+
+      // then
+      assertThat(password).isNull();
+    }
+
+    @Test
+    @DisplayName("사용자 ID를 username으로 반환한다")
+    void getUsername_shouldReturnUserId() {
+      // when
+      String username = userDetails.getUsername();
+
+      // then
+      assertThat(username).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("계정 만료 여부는 항상 true를 반환한다")
+    void isAccountNonExpired_shouldReturnTrue() {
+      // when
+      boolean nonExpired = userDetails.isAccountNonExpired();
+
+      // then
+      assertThat(nonExpired).isTrue();
+    }
+
+    @Test
+    @DisplayName("자격 증명 만료 여부는 항상 true를 반환한다")
+    void isCredentialsNonExpired_shouldReturnTrue() {
+      // when
+      boolean credentialsNonExpired = userDetails.isCredentialsNonExpired();
+
+      // then
+      assertThat(credentialsNonExpired).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("계정 상태 테스트")
+  class AccountStatusTest {
+
+    @Test
+    @DisplayName("활성 사용자의 경우 계정 잠금 여부는 true를 반환한다")
+    void isAccountNonLocked_shouldReturnTrue_whenUserIsActive() {
+      // when
+      boolean nonLocked = userDetails.isAccountNonLocked();
+
+      // then
+      assertThat(nonLocked).isTrue();
+    }
+
+    @Test
+    @DisplayName("비활성 사용자의 경우 계정 잠금 여부는 false를 반환한다")
+    void isAccountNonLocked_shouldReturnFalse_whenUserIsInactive() {
+      // given
+      User inactiveUser = User.builder()
+          .id(2L)
+          .provider(OAuthProvider.GOOGLE)
+          .socialId("google456")
+          .email("inactive@example.com")
+          .nickname("비활성유저")
+          .isActive(false)
+          .role(RoleType.USER)
+          .build();
+      CustomUserDetails inactiveUserDetails = new CustomUserDetails(inactiveUser);
+
+      // when
+      boolean nonLocked = inactiveUserDetails.isAccountNonLocked();
+
+      // then
+      assertThat(nonLocked).isFalse();
+    }
+
+    @Test
+    @DisplayName("활성 사용자의 경우 계정 활성화 여부는 true를 반환한다")
+    void isEnabled_shouldReturnTrue_whenUserIsActive() {
+      // when
+      boolean enabled = userDetails.isEnabled();
+
+      // then
+      assertThat(enabled).isTrue();
+    }
+
+    @Test
+    @DisplayName("비활성 사용자의 경우 계정 활성화 여부는 false를 반환한다")
+    void isEnabled_shouldReturnFalse_whenUserIsInactive() {
+      // given
+      User inactiveUser = User.builder()
+          .id(2L)
+          .provider(OAuthProvider.GOOGLE)
+          .socialId("google456")
+          .email("inactive@example.com")
+          .nickname("비활성유저")
+          .isActive(false)
+          .role(RoleType.USER)
+          .build();
+      CustomUserDetails inactiveUserDetails = new CustomUserDetails(inactiveUser);
+
+      // when
+      boolean enabled = inactiveUserDetails.isEnabled();
+
+      // then
+      assertThat(enabled).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("User 엔티티 접근 테스트")
+  class UserEntityAccessTest {
+
+    @Test
+    @DisplayName("래핑된 User 엔티티를 올바르게 반환한다")
+    void getUser_shouldReturnWrappedUser() {
+      // when
+      User returnedUser = userDetails.getUser();
+
+      // then
+      assertThat(returnedUser)
+          .isEqualTo(user)
+          .extracting(User::getId, User::getEmail, User::getNickname)
+          .containsExactly(1L, "test@example.com", "테스트유저");
+    }
+  }
+
+  @Nested
+  @DisplayName("관리자 권한 테스트")
+  class AdminRoleTest {
+
+    @Test
+    @DisplayName("관리자 사용자의 경우 ROLE_ADMIN 권한을 반환한다")
+    void getAuthorities_shouldReturnAdminRole_whenUserIsAdmin() {
+      // given
+      User adminUser = User.builder()
+          .id(3L)
+          .provider(OAuthProvider.GOOGLE)
+          .socialId("google789")
+          .email("admin@example.com")
+          .nickname("관리자")
+          .isActive(true)
+          .role(RoleType.ADMIN)
+          .build();
+      CustomUserDetails adminUserDetails = new CustomUserDetails(adminUser);
+
+      // when
+      Collection<? extends GrantedAuthority> authorities = adminUserDetails.getAuthorities();
+
+      // then
+      assertThat(authorities)
+          .isNotNull()
+          .hasSize(1)
+          .extracting(GrantedAuthority::getAuthority)
+          .contains("ROLE_ADMIN");
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request

## 🎯 문제 정의 및 배경

### 🔗 관련 이슈

Closes #74

### 📌 문제 설명

UserApiDocs 인터페이스와 전체 Controller 계층에서 `@AuthenticationPrincipal` 어노테이션에 `Object` 타입을 사용하고 있어 타입 안전성이 떨어지고, 구현체에서 매번 타입 캐스팅이 필요한 상황이었습니다. 또한 Spring Security의 기본 UserDetails만으로는 우리 애플리케이션의 User 엔티티 속성에 직접 접근할 수 없어 비효율적이었습니다.

### 🎭 문제 발생 배경

- UserApiDocs 인터페이스에서 `@AuthenticationPrincipal Object principal` 사용
- Controller 구현체에서 매번 UserDetails로 타입 캐스팅 필요
- User 엔티티의 속성(email, nickname 등)에 직접 접근 불가
- 컴파일 타임에 타입 오류를 감지할 수 없어 런타임 오류 위험 존재

---

## 🔍 원인 분석

### 🐛 근본 원인

1. **타입 안전성 부족**: `@AuthenticationPrincipal Object` 사용으로 인한 컴파일 타임 타입 검증 불가
2. **User 엔티티 접근 제한**: Spring Security 기본 UserDetails로는 User 엔티티 속성에 직접 접근 불가
3. **반복적인 타입 캐스팅**: 모든 Controller에서 Object → UserDetails 캐스팅 필요
4. **테스트 복잡성**: UserDetails 인터페이스의 모든 메서드를 구현해야 하는 번거로움

### 🔬 디버깅 과정

1. UserApiDocs 인터페이스에서 `Object principal` 파라미터 발견
2. 모든 Controller 구현체에서 반복적인 타입 캐스팅 확인
3. 테스트 코드에서 UserDetails Mock 생성의 복잡성 확인
4. User 엔티티 속성 접근을 위한 추가 서비스 호출 필요성 발견

### 💭 고려했던 가능성들

- UserApiDocs 인터페이스에서 Object 대신 UserDetails 직접 사용
- 모든 Controller에서 타입 캐스팅 유지
- User 엔티티 조회를 위한 별도 서비스 호출 추가

---

## 💡 해결 방안

### 🤔 검토한 해결 방법들

#### 방법 1: UserApiDocs에서 UserDetails 타입 직접 사용

- **장점**: 별도 구현체 없이 타입 안전성 확보
- **단점**: User 엔티티 속성 접근 불가, 추가 서비스 호출 필요

#### 방법 2: CustomUserDetails 구현체 추가

- **장점**: Spring Security 표준 준수, User 엔티티와 직접 연동, 타입 안전성과 편의성 동시 확보
- **단점**: 새로운 클래스 추가 필요

### ✅ 선택한 방법과 이유

**CustomUserDetails 구현체 추가**를 선택했습니다.

**이유**
- **타입 안전성**: 컴파일 타임에 타입 검증 가능, Object 타입 캐스팅 제거
- **직접적인 User 엔티티 접근**: getUser() 메서드로 User 속성에 즉시 접근 가능
- **테스트 편의성**: CustomUserDetails 생성이 간단하고 명확
- **일관성**: 전체 애플리케이션에서 통일된 인증 주체 사용
- **유지보수성**: 향후 커스텀 인증 로직 추가 시 확장 용이

---

## 📊 결과 및 영향

### 🚀 개선 사항

- **타입 안전성 향상**: Object → CustomUserDetails로 타입 명확화
- **코드 간소화**: 타입 캐스팅 제거 및 User 속성 직접 접근
- **테스트 작성 용이성**: CustomUserDetails 생성 및 Mock 처리 단순화
- **API 일관성**: 모든 Controller에서 동일한 인증 주체 타입 사용
- **유지보수성 향상**: 컴파일 타임 오류 감지로 안정성 증가

### ⚠️ 주의 사항

- UserApiDocs 인터페이스의 Object 타입을 CustomUserDetails로 변경
- 모든 Controller에서 일관되게 CustomUserDetails 사용 필요
- JWT 인증 필터에서 CustomUserDetails 생성 로직 확인 필수

### 📈 성능 영향

- 성능에 미치는 부정적 영향 없음
- 오히려 직접적인 User 엔티티 접근으로 효율성 향상

---

## 📝 구현 세부사항

### 📁 주요 변경 내용

1. **CustomUserDetails 클래스 구현**: Spring Security UserDetails 인터페이스를 구현하고 User 엔티티 래핑
2. **UserApiDocs 인터페이스 수정**: Object → CustomUserDetails 타입 변경
3. **Controller 계층 통합**: 모든 Controller에서 타입 캐스팅 없이 CustomUserDetails 직접 사용
4. **JWT 인증 필터 수정**: User 조회 후 CustomUserDetails로 Authentication 생성
5. **테스트 코드 개선**: Mock 생성 간소화 및 타입 안전성 확보

---

## 🔧 기술적 변경 사항

### 📁 주요 변경 파일

- `src/main/java/org/nodystudio/nodybackend/security/userdetails/CustomUserDetails.java` (신규)
- `src/main/java/org/nodystudio/nodybackend/controller/thread/ThreadController.java`
- `src/main/java/org/nodystudio/nodybackend/controller/log/LogController.java`
- `src/main/java/org/nodystudio/nodybackend/controller/user/UserController.java`
- `src/main/java/org/nodystudio/nodybackend/security/filter/JwtAuthenticationFilter.java`
- `src/test/java/org/nodystudio/nodybackend/security/userdetails/CustomUserDetailsTest.java` (신규)
- 기존 테스트 파일 5개 수정

### 🛠️ API 변경 사항

API 엔드포인트 자체는 변경되지 않았으나, 내부적으로 사용자 정보 처리 방식이 개선되었습니다.

#### 변경된 내부 동작

```java
// 이전: UserApiDocs에서 Object 타입 사용
public ResponseEntity<ApiResponse<UserResponse>> getMe(@AuthenticationPrincipal Object principal) {
    UserDetails userDetails = (UserDetails) principal; // 타입 캐스팅 필요
    // 추가 서비스 호출로 User 정보 조회 필요
}

// 현재: CustomUserDetails 타입 직접 사용
public ResponseEntity<ApiResponse<UserResponse>> getMe(@AuthenticationPrincipal CustomUserDetails userDetails) {
    User user = userDetails.getUser(); // 직접 접근 가능
    // User 엔티티의 모든 속성에 즉시 접근 가능
}
```

### 🗄️ 데이터베이스 변경 사항

- [x] 데이터베이스 변경 없음

### 🔐 보안 관련 변경

- [x] 인증/인가 로직 변경
- [x] JWT 토큰 처리 수정

**보안 개선사항**:
- 타입 안전한 인증 주체 관리로 보안 강화
- 컴파일 타임 타입 검증으로 런타임 오류 방지
- User 엔티티 캡슐화로 무분별한 정보 노출 방지

---

## ✅ 체크리스트

### 📋 코드 품질

- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 주석과 콘솔 로그를 제거했습니다
- [x] 적절한 예외 처리를 구현했습니다
- [x] API 응답 형식이 일관성 있게 구현되었습니다 (`ApiResponse<T>` 사용)

### 🧪 테스트

- [x] 새로운 기능에 대한 단위 테스트를 작성했습니다
- [x] API 테스트 케이스를 추가했습니다

### 📖 문서화

- [x] API 문서가 업데이트되었습니다 (Swagger/OpenAPI)
- [x] 코드 주석이 적절히 작성되었습니다
- [x] 변경 사항에 대한 문서를 작성했습니다

### 🔧 설정 및 환경

- [x] 개발 환경에서 정상 동작을 확인했습니다
- [x] 프로덕션 환경 설정을 고려했습니다
- [x] 환경별 설정 파일이 적절히 구성되었습니다 (dev, prod)
- [x] 의존성 추가 시 버전 충돌을 확인했습니다

---

## 🧪 테스트 결과

### 🔍 테스트 시나리오

1. **CustomUserDetails 단위 테스트**: UserDetails 인터페이스 구현 검증
2. **Controller 계층 테스트**: CustomUserDetails 사용 시 정상 동작 확인
3. **통합 테스트**: 실제 인증 플로우에서 CustomUserDetails 동작 검증
4. **JWT 필터 테스트**: 토큰 검증 후 CustomUserDetails 생성 확인

### 📊 테스트 커버리지

- [x] 단위 테스트 커버리지: 100% (CustomUserDetails 11개 테스트)
- [x] 통합 테스트 완료: 309개 테스트 모두 통과

**테스트 세부 결과**:
- CustomUserDetails 테스트: 11개 (100% 성공)
- Controller 테스트: 27개 (100% 성공)  
- 통합 테스트: 26개 (100% 성공)
- 전체 테스트 스위트: 309개 (100% 성공)

---

## 📸 스크린샷 / 로그

### 테스트 실행 결과
```
BUILD SUCCESSFUL in 3s
6 actionable tasks: 3 executed, 3 up-to-date

Test Summary:
- Tests: 309
- Failures: 0  
- Success rate: 100%
```

### 주요 기능 검증
- ✅ CustomUserDetails 생성 및 User 엔티티 접근
- ✅ JWT 인증 필터에서 CustomUserDetails 설정
- ✅ 타입 안전한 Controller 인증 주체 처리
- ✅ 모든 테스트에서 타입 캐스팅 없이 정상 동작


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자 인증에 특화된 CustomUserDetails 클래스를 도입하여 보안 및 사용자 정보 접근 방식을 개선했습니다.

* **리팩터링**
  * 모든 컨트롤러와 API 문서에서 인증 사용자 타입을 CustomUserDetails로 통일하여 일관성을 높였습니다.
  * 서비스 호출 및 로깅 시 사용자 이메일 및 ID 사용 방식이 개선되었습니다.

* **테스트**
  * CustomUserDetails 기반의 인증 컨텍스트로 테스트 코드가 일관되게 변경되었습니다.
  * CustomUserDetails에 대한 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->