### PR TITLE
feat(API): 비로그인 사용자의 공개 컨텐츠 접근 지원 구현

### DIFF
--- a/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
+++ b/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -104,6 +105,9 @@ public class SecurityConfig {
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers("/api/auth/**", "/api/public/**", "/oauth2/**", "/login/**")
             .permitAll()
+            // 공개 조회 API 허용 (비로그인 사용자도 접근 가능)
+            .requestMatchers(HttpMethod.GET, "/api/threads/**").permitAll()
+            .requestMatchers(HttpMethod.GET, "/api/logs/**").permitAll()
             .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
             .requestMatchers("/favicon.ico").permitAll()
             .requestMatchers("/actuator/**").permitAll()
@@ -137,6 +141,9 @@ public class SecurityConfig {
             .requestMatchers("/api/auth/**", "/api/public/**", "/oauth2/**", "/login/**")
             .permitAll()
             .requestMatchers("/api/admin/**").hasRole("ADMIN")
+            // 공개 조회 API 허용 (비로그인 사용자도 접근 가능)
+            .requestMatchers(HttpMethod.GET, "/api/threads/**").permitAll()
+            .requestMatchers(HttpMethod.GET, "/api/logs/**").permitAll()
             .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
             .requestMatchers("/favicon.ico").permitAll()
             .requestMatchers("/actuator/**").permitAll()

--- a/src/main/java/org/nodystudio/nodybackend/controller/log/LogController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/log/LogController.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,6 +39,12 @@ public class LogController implements LogApiDocs {
   private final LogService logService;
   private final ThreadService threadService;
 
+  /**
+   * 로그에 표시할 사용자 정보를 안전하게 가져옵니다. 인증되지 않은 사용자의 경우 "익명"을 반환합니다.
+   */
+  private String getUserDisplayName(CustomUserDetails userDetails) {
+    return userDetails != null ? userDetails.getEmail() : "익명";
+  }
 
   /**
    * 로그 생성 POST /api/logs
@@ -62,11 +69,11 @@ public class LogController implements LogApiDocs {
   @Override
   @GetMapping("/{id}")
   public ResponseEntity<ApiResponse<LogResponse>> getLog(
-      @PathVariable Long id) {
-    CustomUserDetails userDetails = null;
+      @PathVariable Long id,
+      @Nullable @AuthenticationPrincipal CustomUserDetails userDetails) {
 
     log.info("로그 단건 조회 - ID: {}, 사용자: {}", id,
-        userDetails != null ? userDetails.getUser().getId() : "익명");
+        getUserDisplayName(userDetails));
 
     LogResponse response = logService.getLog(id,
         userDetails != null ? userDetails.getEmail() : null);
@@ -81,13 +88,13 @@ public class LogController implements LogApiDocs {
   @GetMapping
   public ResponseEntity<ApiResponse<Page<LogResponse>>> getLogs(
       @Valid @ModelAttribute LogSearchRequest searchRequest,
-      @PageableDefault(size = 20) Pageable pageable) {
-    CustomUserDetails userDetails = null;
+      @PageableDefault(size = 20) Pageable pageable,
+      @Nullable @AuthenticationPrincipal CustomUserDetails userDetails) {
 
     log.info("로그 목록 조회 - 위치: ({}, {}), 반경: {}km, 사용자: {}",
         searchRequest.getLatitude(), searchRequest.getLongitude(),
         searchRequest.getRadiusKm(),
-        userDetails != null ? userDetails.getUser().getId() : "익명");
+        getUserDisplayName(userDetails));
 
     Page<LogResponse> response = logService.searchLogs(searchRequest,
         userDetails != null ? userDetails.getEmail() : null);
@@ -135,11 +142,11 @@ public class LogController implements LogApiDocs {
   @GetMapping("/{logId}/threads")
   public ResponseEntity<ApiResponse<Page<ThreadResponse>>> getLogThreads(
       @PathVariable Long logId,
-      @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
+      @PageableDefault(size = 20, sort = "createdAt") Pageable pageable,
+      @Nullable @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-    CustomUserDetails userDetails = null;
     log.info("로그 스레드 목록 조회 - 로그ID: {}, 사용자: {}",
-        logId, userDetails != null ? userDetails.getUser().getId() : "익명");
+        logId, getUserDisplayName(userDetails));
 
     Page<ThreadResponse> response = threadService.getThreadsByLog(logId,
         userDetails != null ? userDetails.getEmail() : null, pageable);

--- a/src/main/java/org/nodystudio/nodybackend/controller/log/docs/LogApiDocs.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/log/docs/LogApiDocs.java
@@ -83,7 +83,8 @@ public interface LogApiDocs {
       )
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<LogResponse>> getLog(
-      @Parameter(description = "로그 ID") @PathVariable Long id
+      @Parameter(description = "로그 ID") @PathVariable Long id,
+      @Parameter(hidden = true) CustomUserDetails userDetails
   );
 
   @Operation(
@@ -107,7 +108,8 @@ public interface LogApiDocs {
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<LogResponse>>> getLogs(
       @Valid @ModelAttribute LogSearchRequest searchRequest,
-      @Parameter(hidden = true) @PageableDefault(size = 20) Pageable pageable
+      @Parameter(hidden = true) @PageableDefault(size = 20) Pageable pageable,
+      @Parameter(hidden = true) CustomUserDetails userDetails
   );
 
   @Operation(
@@ -204,6 +206,7 @@ public interface LogApiDocs {
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getLogThreads(
       @Parameter(description = "로그 ID") @PathVariable Long logId,
-      @Parameter(hidden = true) @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
+      @Parameter(hidden = true) @PageableDefault(size = 20, sort = "createdAt") Pageable pageable,
+      @Parameter(hidden = true) CustomUserDetails userDetails
   );
 }

--- a/src/main/java/org/nodystudio/nodybackend/controller/thread/ThreadController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/thread/ThreadController.java
@@ -19,8 +19,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -96,8 +96,8 @@ public class ThreadController implements ThreadApiDocs {
   @Override
   @GetMapping("/{id}")
   public ResponseEntity<ApiResponse<ThreadResponse>> getThread(
-      @PathVariable Long id) {
-    CustomUserDetails userDetails = null;
+      @PathVariable Long id,
+      @Nullable @AuthenticationPrincipal CustomUserDetails userDetails) {
 
     log.info("스레드 단건 조회 - ID: {}, 사용자: {}",
         id, getUserDisplayName(userDetails));
@@ -115,8 +115,8 @@ public class ThreadController implements ThreadApiDocs {
   @GetMapping
   public ResponseEntity<ApiResponse<Page<ThreadResponse>>> getThreads(
       @Valid @ModelAttribute ThreadSearchRequest searchRequest,
-      @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
-    CustomUserDetails userDetails = null;
+      @PageableDefault(size = 20, sort = "createdAt") Pageable pageable,
+      @Nullable @AuthenticationPrincipal CustomUserDetails userDetails) {
 
     log.info("스레드 목록 조회 - 키워드: {}, 타입: {}, 로그ID: {}, 사용자: {}",
         searchRequest.getKeyword(),
@@ -170,8 +170,8 @@ public class ThreadController implements ThreadApiDocs {
   @Override
   @GetMapping("/independent")
   public ResponseEntity<ApiResponse<Page<ThreadResponse>>> getIndependentThreads(
-      @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
-    CustomUserDetails userDetails = null;
+      @PageableDefault(size = 20, sort = "createdAt") Pageable pageable,
+      @Nullable @AuthenticationPrincipal CustomUserDetails userDetails) {
     String keyword = null;
 
     log.info("독립 스레드 목록 조회 - 키워드: {}, 사용자: {}", keyword,
@@ -192,8 +192,8 @@ public class ThreadController implements ThreadApiDocs {
   @Override
   @GetMapping("/linked")
   public ResponseEntity<ApiResponse<Page<ThreadResponse>>> getLinkedThreads(
-      @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
-    CustomUserDetails userDetails = null;
+      @PageableDefault(size = 20, sort = "createdAt") Pageable pageable,
+      @Nullable @AuthenticationPrincipal CustomUserDetails userDetails) {
     String keyword = null;
 
     log.info("로그 연결 스레드 목록 조회 - 키워드: {}, 사용자: {}", keyword,

--- a/src/main/java/org/nodystudio/nodybackend/controller/thread/docs/ThreadApiDocs.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/thread/docs/ThreadApiDocs.java
@@ -19,7 +19,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -83,7 +82,8 @@ public interface ThreadApiDocs {
       )
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<ThreadResponse>> getThread(
-      @Parameter(description = "스레드 ID") @PathVariable Long id
+      @Parameter(description = "스레드 ID") @PathVariable Long id,
+      @Parameter(hidden = true) CustomUserDetails userDetails
   );
 
   @Operation(
@@ -107,7 +107,8 @@ public interface ThreadApiDocs {
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getThreads(
       @Valid @ModelAttribute ThreadSearchRequest searchRequest,
-      @Parameter(hidden = true) @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
+      @Parameter(hidden = true) @PageableDefault(size = 20, sort = "createdAt") Pageable pageable,
+      @Parameter(hidden = true) CustomUserDetails userDetails
   );
 
   @Operation(
@@ -195,7 +196,8 @@ public interface ThreadApiDocs {
       )
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getIndependentThreads(
-      @Parameter(hidden = true) @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
+      @Parameter(hidden = true) @PageableDefault(size = 20, sort = "createdAt") Pageable pageable,
+      @Parameter(hidden = true) CustomUserDetails userDetails
   );
 
   @Operation(
@@ -210,6 +212,7 @@ public interface ThreadApiDocs {
       )
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Page<ThreadResponse>>> getLinkedThreads(
-      @Parameter(hidden = true) @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
+      @Parameter(hidden = true) @PageableDefault(size = 20, sort = "createdAt") Pageable pageable,
+      @Parameter(hidden = true) CustomUserDetails userDetails
   );
 }

--- a/src/main/java/org/nodystudio/nodybackend/controller/user/UserController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/user/UserController.java
@@ -43,7 +43,8 @@ public class UserController implements UserApiDocs {
   @GetMapping(value = "/me")
   public ResponseEntity<ApiResponse<UserDetailResponseDto>> getCurrentUser(
       @AuthenticationPrincipal CustomUserDetails userDetails) {
-    UserDetailResponseDto userDetail = userService.getCurrentUser(userDetails.getUser().getId().toString());
+    UserDetailResponseDto userDetail = userService.getCurrentUser(
+        userDetails.getUser().getId().toString());
 
     return ResponseEntity
         .status(SuccessCode.OK.getStatus())
@@ -54,7 +55,7 @@ public class UserController implements UserApiDocs {
    * 사용자의 닉네임을 변경
    *
    * @param userDetails 인증된 사용자 정보 (@ignore)
-   * @param requestDto 닉네임 변경 요청 DTO
+   * @param requestDto  닉네임 변경 요청 DTO
    * @return UserDetailResponseDto 변경된 사용자 정보
    */
   @Override
@@ -62,7 +63,8 @@ public class UserController implements UserApiDocs {
   public ResponseEntity<ApiResponse<UserDetailResponseDto>> updateNickname(
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody UpdateNicknameRequestDto requestDto) {
-    UserDetailResponseDto updatedUser = userService.updateNickname(userDetails.getUser().getId().toString(),
+    UserDetailResponseDto updatedUser = userService.updateNickname(
+        userDetails.getUser().getId().toString(),
         requestDto);
 
     return ResponseEntity

--- a/src/main/java/org/nodystudio/nodybackend/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/nodystudio/nodybackend/security/filter/JwtAuthenticationFilter.java
@@ -141,8 +141,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
           });
 
       CustomUserDetails userDetails = new CustomUserDetails(user);
-      
-      return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+      return new UsernamePasswordAuthenticationToken(userDetails, null,
+          userDetails.getAuthorities());
     } catch (DisabledException e) {
       throw e;
     } catch (Exception e) {

--- a/src/main/java/org/nodystudio/nodybackend/security/userdetails/CustomUserDetails.java
+++ b/src/main/java/org/nodystudio/nodybackend/security/userdetails/CustomUserDetails.java
@@ -12,9 +12,8 @@ import org.springframework.security.core.userdetails.UserDetails;
  * Spring Security의 인증 주체로 사용되는 커스텀 UserDetails 구현체입니다.
  *
  * <p>
- * 이 클래스는 {@link User} 엔티티를 래핑하여 Spring Security가 요구하는
- * {@link UserDetails} 인터페이스를 구현합니다. JWT 기반 인증 시스템에서
- * 인증된 사용자 정보를 보안 컨텍스트에 저장하는 데 사용됩니다.
+ * 이 클래스는 {@link User} 엔티티를 래핑하여 Spring Security가 요구하는 {@link UserDetails} 인터페이스를 구현합니다. JWT 기반 인증
+ * 시스템에서 인증된 사용자 정보를 보안 컨텍스트에 저장하는 데 사용됩니다.
  * </p>
  *
  * @see UserDetails
@@ -41,11 +40,17 @@ public class CustomUserDetails implements UserDetails {
     return user.getRoles();
   }
 
-  public String getEmail() { return user.getEmail(); }
+  public String getEmail() {
+    return user.getEmail();
+  }
 
-  public String getNickname() { return user.getNickname(); }
+  public String getNickname() {
+    return user.getNickname();
+  }
 
-  public OAuthProvider getProvider() { return user.getProvider(); }
+  public OAuthProvider getProvider() {
+    return user.getProvider();
+  }
 
   /**
    * 사용자의 비밀번호를 반환합니다.

--- a/src/test/java/org/nodystudio/nodybackend/controller/log/LogControllerTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/controller/log/LogControllerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.dto.ApiResponse;
 import org.nodystudio.nodybackend.dto.log.LogCreateRequest;
 import org.nodystudio.nodybackend.dto.log.LogResponse;
@@ -33,9 +34,8 @@ import org.nodystudio.nodybackend.dto.log.LogSearchRequest;
 import org.nodystudio.nodybackend.dto.log.LogUpdateRequest;
 import org.nodystudio.nodybackend.dto.thread.ThreadResponse;
 import org.nodystudio.nodybackend.dto.user.UserSummaryResponse;
-import org.nodystudio.nodybackend.service.log.LogService;
-import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
+import org.nodystudio.nodybackend.service.log.LogService;
 import org.nodystudio.nodybackend.service.thread.ThreadService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -68,7 +68,7 @@ class LogControllerTest {
     User mockUser = mock(User.class);
     lenient().when(mockUser.getId()).thenReturn(1L);
     lenient().when(mockUser.getEmail()).thenReturn("test@example.com");
-    
+
     mockUserDetails = new CustomUserDetails(mockUser);
 
     UserSummaryResponse author = UserSummaryResponse.builder()
@@ -128,7 +128,7 @@ class LogControllerTest {
     given(logService.getLog(1L, null)).willReturn(testLogResponse);
 
     // when
-    ResponseEntity<ApiResponse<LogResponse>> response = logController.getLog(1L);
+    ResponseEntity<ApiResponse<LogResponse>> response = logController.getLog(1L, null);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -150,7 +150,7 @@ class LogControllerTest {
     given(logService.getLog(1L, null)).willReturn(testLogResponse);
 
     // when
-    ResponseEntity<ApiResponse<LogResponse>> response = logController.getLog(1L);
+    ResponseEntity<ApiResponse<LogResponse>> response = logController.getLog(1L, null);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -181,7 +181,7 @@ class LogControllerTest {
     // when
     Pageable pageable = PageRequest.of(0, 20);
     ResponseEntity<ApiResponse<Page<LogResponse>>> response = logController.getLogs(searchRequest,
-        pageable);
+        pageable, null);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -222,7 +222,8 @@ class LogControllerTest {
         .willReturn(updatedResponse);
 
     // when
-    ResponseEntity<ApiResponse<LogResponse>> response = logController.updateLog(1L, mockUserDetails, request);
+    ResponseEntity<ApiResponse<LogResponse>> response = logController.updateLog(1L, mockUserDetails,
+        request);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -270,7 +271,7 @@ class LogControllerTest {
 
     // when
     ResponseEntity<ApiResponse<Page<LogResponse>>> response = logController.getLogs(searchRequest,
-        null);
+        null, null);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -308,7 +309,7 @@ class LogControllerTest {
     // when
     Pageable pageable = PageRequest.of(0, 20);
     ResponseEntity<ApiResponse<Page<ThreadResponse>>> response = logController.getLogThreads(
-        logId, pageable);
+        logId, pageable, null);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -348,7 +349,7 @@ class LogControllerTest {
     // when
     Pageable pageable = PageRequest.of(0, 20);
     ResponseEntity<ApiResponse<Page<ThreadResponse>>> response = logController.getLogThreads(
-        logId, pageable);
+        logId, pageable, null);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -373,7 +374,7 @@ class LogControllerTest {
     // when
     Pageable pageable = PageRequest.of(0, 20);
     ResponseEntity<ApiResponse<Page<ThreadResponse>>> response = logController.getLogThreads(
-        logId, pageable);
+        logId, pageable, null);
 
     // then
     assertEquals(200, response.getStatusCode().value());

--- a/src/test/java/org/nodystudio/nodybackend/controller/thread/ThreadControllerTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/controller/thread/ThreadControllerTest.java
@@ -18,6 +18,7 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -29,19 +30,18 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.nodystudio.nodybackend.domain.user.User;
-import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import java.util.List;
 import org.nodystudio.nodybackend.dto.ApiResponse;
 import org.nodystudio.nodybackend.dto.code.ErrorCode;
 import org.nodystudio.nodybackend.dto.thread.ThreadCreateRequest;
 import org.nodystudio.nodybackend.dto.thread.ThreadResponse;
 import org.nodystudio.nodybackend.dto.thread.ThreadSearchRequest;
 import org.nodystudio.nodybackend.dto.user.UserSummaryResponse;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.nodystudio.nodybackend.service.thread.ThreadService;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -93,7 +93,8 @@ class ThreadControllerTest {
     User mockUser = mock(User.class);
     lenient().when(mockUser.getId()).thenReturn(1L);
     lenient().when(mockUser.getEmail()).thenReturn("test@example.com");
-    lenient().when(mockUser.getRoles()).thenReturn(List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    lenient().when(mockUser.getRoles())
+        .thenReturn(List.of(new SimpleGrantedAuthority("ROLE_USER")));
     lenient().when(mockUser.getIsActive()).thenReturn(true);
 
     return new CustomUserDetails(mockUser);
@@ -151,7 +152,7 @@ class ThreadControllerTest {
     given(threadService.getThread(1L, null)).willReturn(threadResponse);
 
     // when
-    ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.getThread(1L);
+    ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.getThread(1L, null);
 
     // then
     assertEquals(200, response.getStatusCode().value());
@@ -172,7 +173,7 @@ class ThreadControllerTest {
     given(threadService.getThread(1L, null)).willReturn(threadResponse);
 
     // when
-    ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.getThread(1L);
+    ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.getThread(1L, null);
 
     // then
     assertEquals(200, response.getStatusCode().value());

--- a/src/test/java/org/nodystudio/nodybackend/integration/ThreadIntegrationTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/integration/ThreadIntegrationTest.java
@@ -26,15 +26,11 @@ import org.nodystudio.nodybackend.dto.thread.ThreadUpdateRequest;
 import org.nodystudio.nodybackend.repository.LogRepository;
 import org.nodystudio.nodybackend.repository.ThreadRepository;
 import org.nodystudio.nodybackend.repository.UserRepository;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
-import java.util.Collection;
-import java.util.List;
 
 
 @DisplayName("Thread 통합 테스트")

--- a/src/test/java/org/nodystudio/nodybackend/repository/ThreadRepositoryTestDataHelper.java
+++ b/src/test/java/org/nodystudio/nodybackend/repository/ThreadRepositoryTestDataHelper.java
@@ -5,10 +5,10 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import org.nodystudio.nodybackend.domain.enums.OAuthProvider;
 import org.nodystudio.nodybackend.domain.log.Log;
 import org.nodystudio.nodybackend.domain.thread.Thread;
 import org.nodystudio.nodybackend.domain.user.RoleType;
-import org.nodystudio.nodybackend.domain.enums.OAuthProvider;
 import org.nodystudio.nodybackend.domain.user.User;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
@@ -66,13 +66,13 @@ public class ThreadRepositoryTestDataHelper {
    *
    *                      <h3>사용 예시:</h3>
    *                      <pre>{@code
-   *                                           // 스레드들의 생성일시를 5분 간격으로 설정
-   *                                           LocalDateTime baseTime = LocalDateTime.of(2024, 1, 1, 10, 0, 0);
-   *                                           for (int i = 0; i < threads.size(); i++) {
-   *                                               updateThreadCreatedAt(entityManager, threads.get(i).getId(),
-   *                                                                    baseTime.plusMinutes(i * 5));
-   *                                           }
-   *                                           }</pre>
+   *                                                                // 스레드들의 생성일시를 5분 간격으로 설정
+   *                                                                LocalDateTime baseTime = LocalDateTime.of(2024, 1, 1, 10, 0, 0);
+   *                                                                for (int i = 0; i < threads.size(); i++) {
+   *                                                                    updateThreadCreatedAt(entityManager, threads.get(i).getId(),
+   *                                                                                         baseTime.plusMinutes(i * 5));
+   *                                                                }
+   *                                                                }</pre>
    */
   public static void updateThreadCreatedAt(TestEntityManager entityManager, Long threadId,
       LocalDateTime createdAt) {

--- a/src/test/java/org/nodystudio/nodybackend/security/handler/OAuth2LoginSuccessHandlerTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/security/handler/OAuth2LoginSuccessHandlerTest.java
@@ -105,7 +105,8 @@ class OAuth2LoginSuccessHandlerTest {
     ReflectionTestUtils.setField(successHandler, "cookieDomain", "localhost");
     ReflectionTestUtils.setField(successHandler, "cookieSameSite", "Strict");
 
-    given(clientRegistrationRepository.findByRegistrationId(OAuthProvider.GOOGLE.getValue())).willReturn(
+    given(clientRegistrationRepository.findByRegistrationId(
+        OAuthProvider.GOOGLE.getValue())).willReturn(
         clientRegistration);
   }
 
@@ -195,7 +196,8 @@ class OAuth2LoginSuccessHandlerTest {
   void onAuthenticationSuccess_shouldRedirectToErrorPage_whenInvalidRedirectUrl()
       throws IOException {
     // given
-    given(userRepository.findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345")).willReturn(
+    given(
+        userRepository.findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345")).willReturn(
         Optional.of(testUser));
     given(tokenProvider.createAccessToken(testUser)).willReturn(accessToken);
     given(tokenProvider.createRefreshToken(testUser)).willReturn(refreshToken);

--- a/src/test/java/org/nodystudio/nodybackend/security/jwt/TokenProviderTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/security/jwt/TokenProviderTest.java
@@ -14,9 +14,9 @@ import javax.crypto.SecretKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.nodystudio.nodybackend.domain.user.User;
-import org.nodystudio.nodybackend.domain.user.RoleType;
 import org.nodystudio.nodybackend.domain.enums.OAuthProvider;
+import org.nodystudio.nodybackend.domain.user.RoleType;
+import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.dto.code.ErrorCode;
 import org.nodystudio.nodybackend.exception.custom.InvalidTokenException;
 

--- a/src/test/java/org/nodystudio/nodybackend/security/userdetails/CustomUserDetailsTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/security/userdetails/CustomUserDetailsTest.java
@@ -32,7 +32,7 @@ class CustomUserDetailsTest {
         .isActive(true)
         .role(RoleType.USER)
         .build();
-    
+
     userDetails = new CustomUserDetails(user);
   }
 

--- a/src/test/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -113,7 +112,8 @@ class CustomOAuth2UserServiceTest {
     given(userRepository.findByEmailAndDeletedAtAfter(anyString(),
         any(LocalDateTime.class))).willReturn(
         Optional.empty());
-    given(userRepository.findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345")).willReturn(
+    given(
+        userRepository.findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345")).willReturn(
         Optional.empty());
     given(userRepository.saveAndFlush(any(User.class))).willAnswer(invocation -> {
       User userToSave = invocation.getArgument(0);
@@ -156,7 +156,8 @@ class CustomOAuth2UserServiceTest {
     given(userInfoEndpoint.getUserNameAttributeName()).willReturn(userNameAttributeName);
     given(delegateUserService.loadUser(userRequest)).willReturn(mockOAuth2User);
     given(mockOAuth2User.getAttributes()).willReturn(googleAttributes);
-    given(userRepository.findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE, "google_12345"))
+    given(userRepository.findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE,
+        "google_12345"))
         .willReturn(Optional.of(existingUser));
 
     // when
@@ -196,7 +197,8 @@ class CustomOAuth2UserServiceTest {
         });
 
     assertThat(actualException).isSameAs(expectedException);
-    then(userRepository).should(never()).findByProviderAndSocialId(any(OAuthProvider.class), anyString());
+    then(userRepository).should(never())
+        .findByProviderAndSocialId(any(OAuthProvider.class), anyString());
     then(userRepository).should(never()).saveAndFlush(any(User.class));
   }
 
@@ -231,7 +233,8 @@ class CustomOAuth2UserServiceTest {
     given(mockOAuth2User.getAttributes()).willReturn(googleAttributes);
 
     // 활성 사용자 없음
-    given(userRepository.findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE, "google_12345"))
+    given(userRepository.findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE,
+        "google_12345"))
         .willReturn(Optional.empty());
 
     // 30일 이내 탈퇴한 사용자 존재
@@ -272,7 +275,8 @@ class CustomOAuth2UserServiceTest {
     given(mockOAuth2User.getAttributes()).willReturn(googleAttributes);
 
     // 활성 사용자 없음
-    given(userRepository.findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE, "google_12345"))
+    given(userRepository.findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE,
+        "google_12345"))
         .willReturn(Optional.empty());
 
     // 재가입 제한 없음 (30일 지남)
@@ -302,7 +306,8 @@ class CustomOAuth2UserServiceTest {
         .findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE, "google_12345");
     then(userRepository).should(times(1))
         .findByEmailAndDeletedAtAfter(eq("test@example.com"), any(LocalDateTime.class));
-    then(userRepository).should(times(1)).findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345");
+    then(userRepository).should(times(1))
+        .findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345");
     then(userRepository).should(never()).saveAndFlush(any(User.class));
 
     // 계정이 재활성화되었는지 확인 (30일 유예기간 완전 복구)

--- a/src/test/java/org/nodystudio/nodybackend/util/PageableUtilsTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/util/PageableUtilsTest.java
@@ -46,7 +46,8 @@ class PageableUtilsTest {
   @DisplayName("Thread 페이지네이션 객체 생성 - 유효한 필드")
   void createThreadPageable_ValidFields_Success() {
     // when
-    Pageable pageable = PageableUtils.createThreadPageable(0, 10, ThreadSortField.VIEW_COUNT, SortDirection.ASC);
+    Pageable pageable = PageableUtils.createThreadPageable(0, 10, ThreadSortField.VIEW_COUNT,
+        SortDirection.ASC);
 
     // then
     assertThat(pageable.getPageNumber()).isEqualTo(0);
@@ -61,7 +62,8 @@ class PageableUtilsTest {
   void createThreadPageable_EnumPreventInvalidField() {
     // enum 사용으로 유효하지 않은 필드 입력이 컴파일 타임에 방지됨
     // 기본값 사용 테스트
-    Pageable pageable = PageableUtils.createThreadPageable(0, 10, ThreadSortField.CREATED_AT, SortDirection.ASC);
+    Pageable pageable = PageableUtils.createThreadPageable(0, 10, ThreadSortField.CREATED_AT,
+        SortDirection.ASC);
 
     // then
     assertThat(pageable.getPageNumber()).isEqualTo(0);


### PR DESCRIPTION
# Pull Request

## 🎯 문제 정의 및 배경

### 🔗 관련 이슈

Closes #78

### 📌 문제 설명

비로그인 사용자가 공개 컨텐츠(스레드, 로그)에 접근할 수 없어 초기 사용자 유입에 제약이 있었습니다.

### 🎭 문제 발생 배경

- 모든 API 엔드포인트가 인증 필수로 설정되어 있어 비회원 사용자는 컨텐츠 확인 불가
- 위치 기반 소셜 로깅 플랫폼 특성상 지역별 공개 컨텐츠를 보여주는 것이 사용자 유입에 중요
- 기존 하드코딩된 `userDetails = null` 코드는 실제 비로그인 지원이 아닌 플레이스홀더였음

---

## 🔍 원인 분석

### 🐛 근본 원인

1. **Spring Security 설정**: 모든 API 엔드포인트가 `.anyRequest().authenticated()` 정책 적용
2. **컨트롤러 구조**: `@AuthenticationPrincipal`이 필수로 설정되어 비인증 요청 시 오류 발생
3. **하드코딩된 null**: 실제 비로그인 지원이 아닌 임시 코드로 구현되어 있었음

### 🔬 디버깅 과정

1. SecurityConfig.java에서 `permitAll()` 설정이 GET 엔드포인트에 적용되지 않음을 확인
2. ThreadController/LogController에서 `CustomUserDetails userDetails = null` 하드코딩 발견
3. `@AuthenticationPrincipal(required = false)` 지원하지 않음을 확인하고 `@Nullable` 대안 적용

### 💭 고려했던 가능성들

- JWT 토큰 검증 로직 문제
- CORS 설정 이슈
- 서비스 레이어에서의 권한 검증 문제

---

## 💡 해결 방안

### 🤔 검토한 해결 방법들

#### 방법 1: 별도의 Public API 엔드포인트 생성

- **장점**: 기존 API 구조 유지, 명확한 분리
- **단점**: 코드 중복, API 엔드포인트 증가, 유지보수 복잡성

#### 방법 2: 기존 API에서 선택적 인증 지원

- **장점**: 코드 재사용, 단일 엔드포인트 관리, 확장성
- **단점**: 기존 컨트롤러 메서드 시그니처 변경 필요

### ✅ 선택한 방법과 이유

**방법 2: 기존 API에서 선택적 인증 지원**을 선택했습니다.

- 코드 중복을 피하고 유지보수성을 높임
- 서비스 레이어에서 이미 null 안전성 처리가 구현되어 있어 추가 작업 최소화
- RESTful 원칙에 따라 동일한 리소스에 대한 단일 엔드포인트 유지

---

## 📊 결과 및 영향

### 🚀 개선 사항

- 비로그인 사용자도 공개 스레드/로그 조회 가능
- 사용자 초기 유입 경로 개선
- 위치 기반 공개 컨텐츠 탐색 기능 제공
- 소셜미디어 플랫폼으로서의 접근성 향상

### ⚠️ 주의 사항

- 공개 설정된 컨텐츠만 조회 가능 (private 컨텐츠는 여전히 인증 필수)
- 로그에서 익명 사용자 접근을 구분하여 모니터링 필요
- 스팸/악용 방지를 위한 Rate Limiting 고려 필요

### 📈 성능 영향

- 인증 과정 생략으로 GET 요청 응답 시간 소폭 개선 예상
- 캐싱 전략 최적화 여지 제공 (비인증 요청에 대한 별도 캐시 정책)

---

## 📝 구현 세부사항

### 📁 주요 변경 내용

1. **Spring Security 설정 수정**: GET `/api/threads/**`, `/api/logs/**`에 `permitAll()` 적용
2. **컨트롤러 메서드 개선**: `@Nullable @AuthenticationPrincipal` 패턴 적용
3. **API 문서 업데이트**: Swagger 인터페이스에 새로운 메서드 시그니처 반영
4. **테스트 코드 보완**: 익명 사용자 시나리오 테스트 추가

---

## 🔧 기술적 변경 사항

### 📁 주요 변경 파일

- `src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java`
- `src/main/java/org/nodystudio/nodybackend/controller/thread/ThreadController.java`
- `src/main/java/org/nodystudio/nodybackend/controller/log/LogController.java`
- `src/main/java/org/nodystudio/nodybackend/controller/thread/docs/ThreadApiDocs.java`
- `src/main/java/org/nodystudio/nodybackend/controller/log/docs/LogApiDocs.java`
- `src/test/java/org/nodystudio/nodybackend/integration/ThreadIntegrationTest.java`
- `src/test/java/org/nodystudio/nodybackend/controller/thread/ThreadControllerTest.java`
- `src/test/java/org/nodystudio/nodybackend/controller/log/LogControllerTest.java`

### 🛠️ API 변경 사항

#### 변경된 엔드포인트

```http
GET /api/threads/{id}          # 인증 선택적 (public 스레드는 비인증 접근 가능)
GET /api/threads               # 인증 선택적 (public 스레드만 조회)
GET /api/threads/independent   # 인증 선택적 (public 독립 스레드만 조회)
GET /api/threads/linked        # 인증 선택적 (public 로그 연결 스레드만 조회)
GET /api/logs/{id}             # 인증 선택적 (public 로그는 비인증 접근 가능)
GET /api/logs                  # 인증 선택적 (public 로그만 조회)
GET /api/logs/{logId}/threads  # 인증 선택적 (public 로그의 스레드만 조회)
```

### 🗄️ 데이터베이스 변경 사항

- [x] 데이터베이스 변경 없음

### 🔐 보안 관련 변경

- [x] 인증/인가 로직 변경
- [x] CORS 설정 수정

---

## ✅ 체크리스트

### 📋 코드 품질

- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 주석과 콘솔 로그를 제거했습니다
- [x] 적절한 예외 처리를 구현했습니다
- [x] API 응답 형식이 일관성 있게 구현되었습니다 (`ApiResponse<T>` 사용)

### 🧪 테스트

- [x] 새로운 기능에 대한 단위 테스트를 작성했습니다
- [x] API 테스트 케이스를 추가했습니다

### 📖 문서화

- [x] API 문서가 업데이트되었습니다 (Swagger/OpenAPI)
- [x] 코드 주석이 적절히 작성되었습니다
- [x] 변경 사항에 대한 문서를 작성했습니다

### 🔧 설정 및 환경

- [x] 개발 환경에서 정상 동작을 확인했습니다
- [x] 프로덕션 환경 설정을 고려했습니다
- [x] 환경별 설정 파일이 적절히 구성되었습니다 (dev, prod)
- [x] 의존성 추가 시 버전 충돌을 확인했습니다

---

## 🧪 테스트 결과

### 🔍 테스트 시나리오

1. **익명 사용자 공개 스레드 조회**: 인증 없이 public 스레드 조회 성공
2. **익명 사용자 공개 로그 조회**: 인증 없이 public 로그 조회 성공
3. **익명 사용자 private 컨텐츠 접근**: 적절한 권한 없음 처리
4. **인증된 사용자 기존 기능**: 기존 인증 기반 기능 정상 동작
5. **위치 기반 검색**: 비인증 상태에서 위치 기반 공개 로그 검색 성공

### 📊 테스트 커버리지

- [x] 단위 테스트 커버리지: 기존 레벨 유지
- [x] 통합 테스트 완료

---

## 🚀 배포 시 주의사항

1. **모니터링 강화**: 익명 사용자 트래픽 모니터링 설정 필요
2. **Rate Limiting**: 비인증 API 호출에 대한 Rate Limiting 고려
3. **캐시 전략**: 공개 컨텐츠에 대한 캐싱 정책 최적화 검토
4. **보안 정책**: 추후 스팸/악용 방지를 위한 추가 보안 정책 필요 시 고려

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 인증 없이도 `/api/threads/**` 및 `/api/logs/**` GET 요청이 가능하도록 허용되었습니다.

* **버그 수정**
  * 로그 및 스레드 관련 API에서 인증 정보가 없을 때도 안전하게 동작하도록 사용자 정보 처리 방식이 개선되었습니다.

* **문서**
  * API 문서 인터페이스에 사용자 정보 관련 파라미터가 추가되었습니다.

* **스타일**
  * 코드 및 테스트 파일의 포맷팅과 import 정리가 이루어졌습니다.

* **테스트**
  * 변경된 메서드 시그니처에 맞춰 테스트 코드가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->