### PR TITLE
feat(privacy): Soft Delete 패턴을 적용한 계정 삭제 구현(사용자 데이터 프라이버시 보호 개선)

### DIFF
--- a/src/main/java/org/nodystudio/nodybackend/domain/log/Log.java
+++ b/src/main/java/org/nodystudio/nodybackend/domain/log/Log.java
@@ -17,6 +17,7 @@ import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -37,7 +38,8 @@ import org.nodystudio.nodybackend.domain.user.User;
     indexes = {@Index(name = "idx_logs_user_id", columnList = "user_id"),
         @Index(name = "idx_logs_location", columnList = "latitude, longitude"),
         @Index(name = "idx_logs_is_public", columnList = "is_public"),
-        @Index(name = "idx_logs_created_at", columnList = "created_at")})
+        @Index(name = "idx_logs_created_at", columnList = "created_at"),
+        @Index(name = "idx_logs_deactivated_at", columnList = "deactivated_at")})
 public class Log extends BaseTimeEntity {
 
   @Id
@@ -82,6 +84,13 @@ public class Log extends BaseTimeEntity {
   @ColumnDefault("0")
   @Builder.Default
   private Long viewCount = 0L;
+
+  /**
+   * 계정 탈퇴 시 로그 비활성화 시점을 기록합니다.
+   * NULL이면 활성 상태, NULL이 아니면 비활성 상태입니다.
+   */
+  @Column(name = "deactivated_at")
+  private LocalDateTime deactivatedAt;
 
   /**
    * 로그 내용을 업데이트합니다.

--- a/src/main/java/org/nodystudio/nodybackend/domain/log/Log.java
+++ b/src/main/java/org/nodystudio/nodybackend/domain/log/Log.java
@@ -151,4 +151,38 @@ public class Log extends BaseTimeEntity {
     }
     return viewer != null && isOwnedBy(viewer);
   }
+
+  /**
+   * 로그를 비활성화합니다.
+   * 계정 탈퇴 시 사용되며, 비활성화된 로그는 일반 조회에서 제외됩니다.
+   */
+  public void deactivate() {
+    this.deactivatedAt = LocalDateTime.now();
+  }
+
+  /**
+   * 로그를 재활성화합니다.
+   * 계정 복구 시 사용되며, 원본 공개설정이 그대로 복원됩니다.
+   */
+  public void reactivate() {
+    this.deactivatedAt = null;
+  }
+
+  /**
+   * 로그가 활성 상태인지 확인합니다.
+   *
+   * @return 활성 상태이면 true, 비활성 상태이면 false
+   */
+  public boolean isActive() {
+    return this.deactivatedAt == null;
+  }
+
+  /**
+   * 로그가 비활성 상태인지 확인합니다.
+   *
+   * @return 비활성 상태이면 true, 활성 상태이면 false
+   */
+  public boolean isDeactivated() {
+    return this.deactivatedAt != null;
+  }
 }

--- a/src/main/java/org/nodystudio/nodybackend/domain/thread/Thread.java
+++ b/src/main/java/org/nodystudio/nodybackend/domain/thread/Thread.java
@@ -185,4 +185,38 @@ public class Thread extends BaseTimeEntity {
       comment.setThread(null);
     }
   }
+
+  /**
+   * 스레드를 비활성화합니다.
+   * 계정 탈퇴 시 사용되며, 비활성화된 스레드는 일반 조회에서 제외됩니다.
+   */
+  public void deactivate() {
+    this.deactivatedAt = LocalDateTime.now();
+  }
+
+  /**
+   * 스레드를 재활성화합니다.
+   * 계정 복구 시 사용되며, 원본 공개설정이 그대로 복원됩니다.
+   */
+  public void reactivate() {
+    this.deactivatedAt = null;
+  }
+
+  /**
+   * 스레드가 활성 상태인지 확인합니다.
+   *
+   * @return 활성 상태이면 true, 비활성 상태이면 false
+   */
+  public boolean isActive() {
+    return this.deactivatedAt == null;
+  }
+
+  /**
+   * 스레드가 비활성 상태인지 확인합니다.
+   *
+   * @return 비활성 상태이면 true, 활성 상태이면 false
+   */
+  public boolean isDeactivated() {
+    return this.deactivatedAt != null;
+  }
 }

--- a/src/main/java/org/nodystudio/nodybackend/domain/thread/Thread.java
+++ b/src/main/java/org/nodystudio/nodybackend/domain/thread/Thread.java
@@ -14,6 +14,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -36,7 +37,8 @@ import org.nodystudio.nodybackend.domain.user.User;
     @Index(name = "idx_threads_user_id", columnList = "user_id"),
     @Index(name = "idx_threads_log_id", columnList = "log_id"),
     @Index(name = "idx_threads_is_public", columnList = "is_public"),
-    @Index(name = "idx_threads_created_at", columnList = "created_at")
+    @Index(name = "idx_threads_created_at", columnList = "created_at"),
+    @Index(name = "idx_threads_deactivated_at", columnList = "deactivated_at")
 })
 public class Thread extends BaseTimeEntity {
 
@@ -72,6 +74,13 @@ public class Thread extends BaseTimeEntity {
   @OneToMany(mappedBy = "thread", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   @Builder.Default
   private List<Comment> comments = new ArrayList<>();
+
+  /**
+   * 계정 탈퇴 시 스레드 비활성화 시점을 기록합니다.
+   * NULL이면 활성 상태, NULL이 아니면 비활성 상태입니다.
+   */
+  @Column(name = "deactivated_at")
+  private LocalDateTime deactivatedAt;
 
   /**
    * 스레드 내용을 업데이트합니다.

--- a/src/main/java/org/nodystudio/nodybackend/exception/custom/DuplicateNicknameException.java
+++ b/src/main/java/org/nodystudio/nodybackend/exception/custom/DuplicateNicknameException.java
@@ -1,0 +1,35 @@
+package org.nodystudio.nodybackend.exception.custom;
+
+import org.nodystudio.nodybackend.dto.code.ErrorCode;
+
+/**
+ * 중복된 닉네임 사용 시 발생하는 예외
+ */
+public class DuplicateNicknameException extends BusinessException {
+
+  /**
+   * 중복 닉네임 예외 생성자 (기본 메시지)
+   */
+  public DuplicateNicknameException() {
+    super(ErrorCode.VALIDATION_ERROR);
+  }
+
+  /**
+   * 중복 닉네임 예외 생성자 (커스텀 메시지)
+   *
+   * @param message 예외 메시지
+   */
+  public DuplicateNicknameException(String message) {
+    super(message, ErrorCode.VALIDATION_ERROR);
+  }
+
+  /**
+   * 중복 닉네임 예외 생성자 (커스텀 메시지 및 원인)
+   *
+   * @param message 예외 메시지
+   * @param cause   원인 예외
+   */
+  public DuplicateNicknameException(String message, Throwable cause) {
+    super(message, ErrorCode.VALIDATION_ERROR, cause);
+  }
+}

--- a/src/main/java/org/nodystudio/nodybackend/repository/CommentRepository.java
+++ b/src/main/java/org/nodystudio/nodybackend/repository/CommentRepository.java
@@ -6,6 +6,7 @@ import org.nodystudio.nodybackend.domain.comment.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -107,4 +108,20 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
       """)
   List<Comment> findByThreadIdAndAuthorId(@Param("threadId") Long threadId,
       @Param("authorId") Long authorId);
+
+  /**
+   * 사용자별 댓글을 비활성화합니다 (계정 탈퇴 시).
+   * Soft delete로 처리하여 데이터는 보존하되 공개되지 않도록 합니다.
+   */
+  @Modifying
+  @Query("UPDATE Comment c SET c.deletedAt = CURRENT_TIMESTAMP WHERE c.author.id = :userId AND c.deletedAt IS NULL")
+  int deactivateByUserId(@Param("userId") Long userId);
+
+  /**
+   * 사용자별 댓글을 재활성화합니다 (계정 복구 시).
+   * Soft delete 상태를 해제하여 댓글을 다시 공개합니다.
+   */
+  @Modifying
+  @Query("UPDATE Comment c SET c.deletedAt = NULL WHERE c.author.id = :userId AND c.deletedAt IS NOT NULL")
+  int reactivateByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/nodystudio/nodybackend/repository/LikeRepository.java
+++ b/src/main/java/org/nodystudio/nodybackend/repository/LikeRepository.java
@@ -104,4 +104,20 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
    * @param targetId   대상 ID
    */
   void deleteByUserIdAndTargetTypeAndTargetId(Long userId, TargetType targetType, Long targetId);
+
+  /**
+   * 사용자별 좋아요를 비활성화합니다 (계정 탈퇴 시).
+   * 물리적 삭제 대신 isActive = false로 설정합니다.
+   */
+  @Modifying
+  @Query("UPDATE Like l SET l.isActive = false WHERE l.user.id = :userId AND l.isActive = true")
+  int deactivateByUserId(@Param("userId") Long userId);
+
+  /**
+   * 사용자별 좋아요를 재활성화합니다 (계정 복구 시).
+   * 비활성화된 좋아요를 다시 활성화합니다.
+   */
+  @Modifying
+  @Query("UPDATE Like l SET l.isActive = true WHERE l.user.id = :userId AND l.isActive = false")
+  int reactivateByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/nodystudio/nodybackend/repository/LogRepository.java
+++ b/src/main/java/org/nodystudio/nodybackend/repository/LogRepository.java
@@ -7,7 +7,6 @@ import org.nodystudio.nodybackend.domain.log.Log;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -175,18 +174,15 @@ public interface LogRepository extends JpaRepository<Log, Long> {
       Pageable pageable);
 
   /**
-   * 사용자별 로그를 비활성화합니다 (계정 탈퇴 시).
-   * Soft delete로 처리하여 데이터는 보존하되 공개되지 않도록 합니다.
+   * 활성화된 사용자 로그를 모두 조회합니다 (비활성화 작업용).
    */
-  @Modifying
-  @Query("UPDATE Log l SET l.deactivatedAt = CURRENT_TIMESTAMP WHERE l.user.id = :userId AND l.deactivatedAt IS NULL")
-  int deactivateByUserId(@Param("userId") Long userId);
+  @Query("SELECT l FROM Log l WHERE l.user.id = :userId AND l.deactivatedAt IS NULL")
+  List<Log> findActiveLogsByUserId(@Param("userId") Long userId);
 
   /**
-   * 사용자별 로그를 재활성화합니다 (계정 복구 시).
-   * Soft delete 상태를 해제하여 로그를 다시 공개합니다.
+   * 비활성화된 사용자 로그를 모두 조회합니다 (재활성화 작업용).
    */
-  @Modifying
-  @Query("UPDATE Log l SET l.deactivatedAt = NULL WHERE l.user.id = :userId AND l.deactivatedAt IS NOT NULL")
-  int reactivateByUserId(@Param("userId") Long userId);
+  @Query("SELECT l FROM Log l WHERE l.user.id = :userId AND l.deactivatedAt IS NOT NULL")
+  List<Log> findDeactivatedLogsByUserId(@Param("userId") Long userId);
+
 }

--- a/src/main/java/org/nodystudio/nodybackend/repository/LogRepository.java
+++ b/src/main/java/org/nodystudio/nodybackend/repository/LogRepository.java
@@ -7,6 +7,7 @@ import org.nodystudio.nodybackend.domain.log.Log;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -19,14 +20,16 @@ import org.springframework.stereotype.Repository;
 public interface LogRepository extends JpaRepository<Log, Long> {
 
   /**
-   * 사용자별 로그 조회
+   * 사용자별 로그 조회 (활성화된 로그만)
    */
-  List<Log> findByUserIdOrderByCreatedAtDesc(Long userId);
+  @Query("SELECT l FROM Log l WHERE l.user.id = :userId AND l.deactivatedAt IS NULL ORDER BY l.createdAt DESC")
+  List<Log> findByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
 
   /**
-   * 사용자별 로그 조회 (페이징)
+   * 사용자별 로그 조회 (페이징, 활성화된 로그만)
    */
-  Page<Log> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+  @Query("SELECT l FROM Log l WHERE l.user.id = :userId AND l.deactivatedAt IS NULL ORDER BY l.createdAt DESC")
+  Page<Log> findByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId, Pageable pageable);
 
   /**
    * 특정 좌표 반경 내 로그 조회 (Haversine 공식 사용)
@@ -45,6 +48,7 @@ public interface LogRepository extends JpaRepository<Log, Long> {
       FROM logs l
       WHERE l.latitude IS NOT NULL
         AND l.longitude IS NOT NULL
+        AND l.deactivated_at IS NULL
         AND (6371 * acos(cos(radians(:latitude)) * cos(radians(l.latitude)) *
              cos(radians(l.longitude) - radians(:longitude)) +
              sin(radians(:latitude)) * sin(radians(l.latitude)))) <= :radiusKm
@@ -54,6 +58,7 @@ public interface LogRepository extends JpaRepository<Log, Long> {
       FROM logs l
       WHERE l.latitude IS NOT NULL
         AND l.longitude IS NOT NULL
+        AND l.deactivated_at IS NULL
         AND (6371 * acos(cos(radians(:latitude)) * cos(radians(l.latitude)) *
              cos(radians(l.longitude) - radians(:longitude)) +
              sin(radians(:latitude)) * sin(radians(l.latitude)))) <= :radiusKm
@@ -75,6 +80,7 @@ public interface LogRepository extends JpaRepository<Log, Long> {
       WHERE l.latitude IS NOT NULL
         AND l.longitude IS NOT NULL
         AND l.is_public = true
+        AND l.deactivated_at IS NULL
         AND (6371 * acos(cos(radians(:latitude)) * cos(radians(l.latitude)) *
              cos(radians(l.longitude) - radians(:longitude)) +
              sin(radians(:latitude)) * sin(radians(l.latitude)))) <= :radiusKm
@@ -88,6 +94,7 @@ public interface LogRepository extends JpaRepository<Log, Long> {
       WHERE l.latitude IS NOT NULL
         AND l.longitude IS NOT NULL
         AND l.is_public = true
+        AND l.deactivated_at IS NULL
         AND (6371 * acos(cos(radians(:latitude)) * cos(radians(l.latitude)) *
              cos(radians(l.longitude) - radians(:longitude)) +
              sin(radians(:latitude)) * sin(radians(l.latitude)))) <= :radiusKm
@@ -109,6 +116,7 @@ public interface LogRepository extends JpaRepository<Log, Long> {
       FROM logs l
       WHERE l.latitude IS NOT NULL
         AND l.longitude IS NOT NULL
+        AND l.deactivated_at IS NULL
         AND (l.is_public = true OR l.user_id = :userId)
         AND (6371 * acos(cos(radians(:latitude)) * cos(radians(l.latitude)) *
              cos(radians(l.longitude) - radians(:longitude)) +
@@ -122,6 +130,7 @@ public interface LogRepository extends JpaRepository<Log, Long> {
       FROM logs l
       WHERE l.latitude IS NOT NULL
         AND l.longitude IS NOT NULL
+        AND l.deactivated_at IS NULL
         AND (l.is_public = true OR l.user_id = :userId)
         AND (6371 * acos(cos(radians(:latitude)) * cos(radians(l.latitude)) *
              cos(radians(l.longitude) - radians(:longitude)) +
@@ -135,30 +144,49 @@ public interface LogRepository extends JpaRepository<Log, Long> {
       Pageable pageable);
 
   /**
-   * 로그 ID와 작성자 확인을 위한 조회
+   * 로그 ID와 작성자 확인을 위한 조회 (활성화된 로그만)
    */
-  Optional<Log> findByIdAndUserId(Long id, Long userId);
+  @Query("SELECT l FROM Log l WHERE l.id = :id AND l.user.id = :userId AND l.deactivatedAt IS NULL")
+  Optional<Log> findByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 
   /**
-   * 공개 로그 또는 특정 사용자의 로그 조회
+   * 공개 로그 또는 특정 사용자의 로그 조회 (활성화된 로그만)
    */
-  @Query("SELECT l FROM Log l WHERE l.id = :id AND (l.isPublic = true OR l.user.id = :userId)")
+  @Query("SELECT l FROM Log l WHERE l.id = :id AND l.deactivatedAt IS NULL AND (l.isPublic = true OR l.user.id = :userId)")
   Optional<Log> findViewableLogByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 
   /**
-   * 공개 로그만 조회
+   * 공개 로그만 조회 (활성화된 로그만)
    */
-  Optional<Log> findByIdAndIsPublicTrue(Long id);
+  @Query("SELECT l FROM Log l WHERE l.id = :id AND l.isPublic = true AND l.deactivatedAt IS NULL")
+  Optional<Log> findByIdAndIsPublicTrue(@Param("id") Long id);
 
   /**
-   * 공개 로그만 전체 조회 (비로그인 사용자용)
+   * 공개 로그만 전체 조회 (비로그인 사용자용, 활성화된 로그만)
    */
+  @Query("SELECT l FROM Log l WHERE l.isPublic = true AND l.deactivatedAt IS NULL ORDER BY l.createdAt DESC")
   Page<Log> findByIsPublicTrueOrderByCreatedAtDesc(Pageable pageable);
 
   /**
-   * 공개 로그 + 특정 사용자의 비공개 로그 조회 (로그인 사용자용)
+   * 공개 로그 + 특정 사용자의 비공개 로그 조회 (로그인 사용자용, 활성화된 로그만)
    */
-  @Query("SELECT l FROM Log l WHERE l.isPublic = true OR l.user.id = :userId ORDER BY l.createdAt DESC")
+  @Query("SELECT l FROM Log l WHERE l.deactivatedAt IS NULL AND (l.isPublic = true OR l.user.id = :userId) ORDER BY l.createdAt DESC")
   Page<Log> findPublicOrUserLogsOrderByCreatedAtDesc(@Param("userId") Long userId,
       Pageable pageable);
+
+  /**
+   * 사용자별 로그를 비활성화합니다 (계정 탈퇴 시).
+   * Soft delete로 처리하여 데이터는 보존하되 공개되지 않도록 합니다.
+   */
+  @Modifying
+  @Query("UPDATE Log l SET l.deactivatedAt = CURRENT_TIMESTAMP WHERE l.user.id = :userId AND l.deactivatedAt IS NULL")
+  int deactivateByUserId(@Param("userId") Long userId);
+
+  /**
+   * 사용자별 로그를 재활성화합니다 (계정 복구 시).
+   * Soft delete 상태를 해제하여 로그를 다시 공개합니다.
+   */
+  @Modifying
+  @Query("UPDATE Log l SET l.deactivatedAt = NULL WHERE l.user.id = :userId AND l.deactivatedAt IS NOT NULL")
+  int reactivateByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/nodystudio/nodybackend/repository/ThreadRepository.java
+++ b/src/main/java/org/nodystudio/nodybackend/repository/ThreadRepository.java
@@ -14,59 +14,68 @@ import org.springframework.stereotype.Repository;
 public interface ThreadRepository extends JpaRepository<Thread, Long> {
 
   /**
-   * 사용자가 소유한 스레드를 조회합니다.
+   * 사용자가 소유한 스레드를 조회합니다 (활성화된 스레드만).
    */
-  Optional<Thread> findByIdAndUserId(Long id, Long userId);
+  @Query("SELECT t FROM Thread t WHERE t.id = :id AND t.user.id = :userId AND t.deactivatedAt IS NULL")
+  Optional<Thread> findByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 
   /**
-   * 공개 스레드를 ID로 조회합니다.
+   * 공개 스레드를 ID로 조회합니다 (활성화된 스레드만).
    */
-  Optional<Thread> findByIdAndIsPublicTrue(Long id);
+  @Query("SELECT t FROM Thread t WHERE t.id = :id AND t.isPublic = true AND t.deactivatedAt IS NULL")
+  Optional<Thread> findByIdAndIsPublicTrue(@Param("id") Long id);
 
   /**
-   * 사용자가 볼 수 있는 스레드를 조회합니다 (공개 스레드 + 본인 스레드).
+   * 사용자가 볼 수 있는 스레드를 조회합니다 (공개 스레드 + 본인 스레드, 활성화된 스레드만).
    */
   @Query("""
           SELECT t FROM Thread t
           WHERE t.id = :threadId
+            AND t.deactivatedAt IS NULL
             AND (t.isPublic = true OR t.user.id = :userId)
       """)
   Optional<Thread> findViewableThreadByIdAndUserId(@Param("threadId") Long threadId,
       @Param("userId") Long userId);
 
   /**
-   * 공개 스레드 목록을 최신순으로 조회합니다.
+   * 공개 스레드 목록을 최신순으로 조회합니다 (활성화된 스레드만).
    */
+  @Query("SELECT t FROM Thread t WHERE t.isPublic = true AND t.deactivatedAt IS NULL ORDER BY t.createdAt DESC")
   Page<Thread> findByIsPublicTrueOrderByCreatedAtDesc(Pageable pageable);
 
   /**
-   * 사용자가 볼 수 있는 스레드 목록을 조회합니다 (공개 스레드 + 본인 스레드).
+   * 사용자가 볼 수 있는 스레드 목록을 조회합니다 (공개 스레드 + 본인 스레드, 활성화된 스레드만).
    */
   @Query("""
           SELECT t FROM Thread t
-          WHERE t.isPublic = true OR t.user.id = :userId
+          WHERE t.deactivatedAt IS NULL
+            AND (t.isPublic = true OR t.user.id = :userId)
           ORDER BY t.createdAt DESC
       """)
   Page<Thread> findPublicOrUserThreadsOrderByCreatedAtDesc(@Param("userId") Long userId,
       Pageable pageable);
 
   /**
-   * 특정 로그에 연결된 스레드 목록을 조회합니다 (공개 스레드만).
+   * 특정 로그에 연결된 스레드 목록을 조회합니다 (공개 스레드만, 활성화된 스레드만).
    */
   @Query("""
           SELECT t FROM Thread t
-          WHERE t.log.id = :logId AND t.isPublic = true
+          WHERE t.log.id = :logId 
+            AND t.isPublic = true 
+            AND t.deactivatedAt IS NULL
           ORDER BY t.createdAt DESC
       """)
   Page<Thread> findPublicThreadsByLogIdOrderByCreatedAtDesc(@Param("logId") Long logId,
       Pageable pageable);
 
   /**
-   * 특정 로그에 연결된 스레드 목록을 조회합니다 (사용자별 권한 고려).
+   * 특정 로그에 연결된 스레드 목록을 조회합니다 (사용자별 권한 고려, 활성화된 스레드만).
    */
   @Query("""
           SELECT t FROM Thread t
-          WHERE t.log.id = :logId AND (t.isPublic = true OR t.user.id = :userId)
+          WHERE t.log.id = :logId 
+            AND t.deactivatedAt IS NULL
+            AND (t.isPublic = true OR t.user.id = :userId)
           ORDER BY t.createdAt DESC
       """)
   Page<Thread> findThreadsByLogIdWithUser(@Param("logId") Long logId,
@@ -74,70 +83,82 @@ public interface ThreadRepository extends JpaRepository<Thread, Long> {
       Pageable pageable);
 
   /**
-   * 특정 사용자가 작성한 스레드 목록을 조회합니다.
+   * 특정 사용자가 작성한 스레드 목록을 조회합니다 (활성화된 스레드만).
    */
-  Page<Thread> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+  @Query("SELECT t FROM Thread t WHERE t.user.id = :userId AND t.deactivatedAt IS NULL ORDER BY t.createdAt DESC")
+  Page<Thread> findByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId, Pageable pageable);
 
   /**
-   * 독립 스레드 목록을 조회합니다 (로그에 연결되지 않은 스레드, 공개만).
+   * 독립 스레드 목록을 조회합니다 (로그에 연결되지 않은 스레드, 공개만, 활성화된 스레드만).
    */
   @Query("""
           SELECT t FROM Thread t
-          WHERE t.log IS NULL AND t.isPublic = true
+          WHERE t.log IS NULL 
+            AND t.isPublic = true 
+            AND t.deactivatedAt IS NULL
           ORDER BY t.createdAt DESC
       """)
   Page<Thread> findIndependentPublicThreadsOrderByCreatedAtDesc(Pageable pageable);
 
   /**
-   * 독립 스레드 목록을 조회합니다 (사용자별 권한 고려).
+   * 독립 스레드 목록을 조회합니다 (사용자별 권한 고려, 활성화된 스레드만).
    */
   @Query("""
           SELECT t FROM Thread t
-          WHERE t.log IS NULL AND (t.isPublic = true OR t.user.id = :userId)
+          WHERE t.log IS NULL 
+            AND t.deactivatedAt IS NULL
+            AND (t.isPublic = true OR t.user.id = :userId)
           ORDER BY t.createdAt DESC
       """)
   Page<Thread> findIndependentThreadsWithUser(@Param("userId") Long userId,
       Pageable pageable);
 
   /**
-   * 로그 연결 스레드 목록을 조회합니다 (로그에 연결된 스레드, 공개만).
+   * 로그 연결 스레드 목록을 조회합니다 (로그에 연결된 스레드, 공개만, 활성화된 스레드만).
    */
   @Query("""
           SELECT t FROM Thread t
-          WHERE t.log IS NOT NULL AND t.isPublic = true
+          WHERE t.log IS NOT NULL 
+            AND t.isPublic = true 
+            AND t.deactivatedAt IS NULL
           ORDER BY t.createdAt DESC
       """)
   Page<Thread> findLinkedPublicThreadsOrderByCreatedAtDesc(Pageable pageable);
 
   /**
-   * 로그 연결 스레드 목록을 조회합니다 (사용자별 권한 고려).
+   * 로그 연결 스레드 목록을 조회합니다 (사용자별 권한 고려, 활성화된 스레드만).
    */
   @Query("""
           SELECT t FROM Thread t
-          WHERE t.log IS NOT NULL AND (t.isPublic = true OR t.user.id = :userId)
+          WHERE t.log IS NOT NULL 
+            AND t.deactivatedAt IS NULL
+            AND (t.isPublic = true OR t.user.id = :userId)
           ORDER BY t.createdAt DESC
       """)
   Page<Thread> findLinkedThreadsWithUser(@Param("userId") Long userId,
       Pageable pageable);
 
   /**
-   * 내용으로 공개 스레드를 검색합니다.
+   * 내용으로 공개 스레드를 검색합니다 (활성화된 스레드만).
    */
   @Query("""
           SELECT t FROM Thread t
-          WHERE t.isPublic = true AND LOWER(t.content) LIKE LOWER(CONCAT('%', :keyword, '%'))
+          WHERE t.isPublic = true 
+            AND t.deactivatedAt IS NULL
+            AND LOWER(t.content) LIKE LOWER(CONCAT('%', :keyword, '%'))
           ORDER BY t.createdAt DESC
       """)
   Page<Thread> searchPublicThreadsByContent(@Param("keyword") String keyword,
       Pageable pageable);
 
   /**
-   * 내용으로 스레드를 검색합니다 (사용자별 권한 고려).
+   * 내용으로 스레드를 검색합니다 (사용자별 권한 고려, 활성화된 스레드만).
    */
   @Query("""
           SELECT t FROM Thread t
-          WHERE (t.isPublic = true OR t.user.id = :userId) AND
-          LOWER(t.content) LIKE LOWER(CONCAT('%', :keyword, '%'))
+          WHERE t.deactivatedAt IS NULL
+            AND (t.isPublic = true OR t.user.id = :userId) 
+            AND LOWER(t.content) LIKE LOWER(CONCAT('%', :keyword, '%'))
           ORDER BY t.createdAt DESC
       """)
   Page<Thread> searchThreadsByContentWithUser(@Param("keyword") String keyword,
@@ -145,14 +166,16 @@ public interface ThreadRepository extends JpaRepository<Thread, Long> {
       Pageable pageable);
 
   /**
-   * 특정 로그에 연결된 스레드 개수를 조회합니다.
+   * 특정 로그에 연결된 스레드 개수를 조회합니다 (활성화된 스레드만).
    */
-  long countByLogId(Long logId);
+  @Query("SELECT COUNT(t) FROM Thread t WHERE t.log.id = :logId AND t.deactivatedAt IS NULL")
+  long countByLogId(@Param("logId") Long logId);
 
   /**
-   * 특정 사용자가 작성한 스레드 개수를 조회합니다.
+   * 특정 사용자가 작성한 스레드 개수를 조회합니다 (활성화된 스레드만).
    */
-  long countByUserId(Long userId);
+  @Query("SELECT COUNT(t) FROM Thread t WHERE t.user.id = :userId AND t.deactivatedAt IS NULL")
+  long countByUserId(@Param("userId") Long userId);
 
   /**
    * 스레드의 조회수를 원자적으로 증가시킵니다. 동시성 이슈를 해결하기 위해 데이터베이스 레벨에서 원자적 증가를 수행합니다.
@@ -160,4 +183,20 @@ public interface ThreadRepository extends JpaRepository<Thread, Long> {
   @Modifying
   @Query("UPDATE Thread t SET t.viewCount = t.viewCount + 1 WHERE t.id = :threadId")
   int incrementViewCount(@Param("threadId") Long threadId);
+
+  /**
+   * 사용자별 스레드를 비활성화합니다 (계정 탈퇴 시).
+   * Soft delete로 처리하여 데이터는 보존하되 공개되지 않도록 합니다.
+   */
+  @Modifying
+  @Query("UPDATE Thread t SET t.deactivatedAt = CURRENT_TIMESTAMP WHERE t.user.id = :userId AND t.deactivatedAt IS NULL")
+  int deactivateByUserId(@Param("userId") Long userId);
+
+  /**
+   * 사용자별 스레드를 재활성화합니다 (계정 복구 시).
+   * Soft delete 상태를 해제하여 스레드를 다시 공개합니다.
+   */
+  @Modifying
+  @Query("UPDATE Thread t SET t.deactivatedAt = NULL WHERE t.user.id = :userId AND t.deactivatedAt IS NOT NULL")
+  int reactivateByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/nodystudio/nodybackend/repository/ThreadRepository.java
+++ b/src/main/java/org/nodystudio/nodybackend/repository/ThreadRepository.java
@@ -1,5 +1,6 @@
 package org.nodystudio.nodybackend.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.nodystudio.nodybackend.domain.thread.Thread;
 import org.springframework.data.domain.Page;
@@ -185,18 +186,15 @@ public interface ThreadRepository extends JpaRepository<Thread, Long> {
   int incrementViewCount(@Param("threadId") Long threadId);
 
   /**
-   * 사용자별 스레드를 비활성화합니다 (계정 탈퇴 시).
-   * Soft delete로 처리하여 데이터는 보존하되 공개되지 않도록 합니다.
+   * 활성화된 사용자 스레드를 모두 조회합니다 (비활성화 작업용).
    */
-  @Modifying
-  @Query("UPDATE Thread t SET t.deactivatedAt = CURRENT_TIMESTAMP WHERE t.user.id = :userId AND t.deactivatedAt IS NULL")
-  int deactivateByUserId(@Param("userId") Long userId);
+  @Query("SELECT t FROM Thread t WHERE t.user.id = :userId AND t.deactivatedAt IS NULL")
+  List<Thread> findActiveThreadsByUserId(@Param("userId") Long userId);
 
   /**
-   * 사용자별 스레드를 재활성화합니다 (계정 복구 시).
-   * Soft delete 상태를 해제하여 스레드를 다시 공개합니다.
+   * 비활성화된 사용자 스레드를 모두 조회합니다 (재활성화 작업용).
    */
-  @Modifying
-  @Query("UPDATE Thread t SET t.deactivatedAt = NULL WHERE t.user.id = :userId AND t.deactivatedAt IS NOT NULL")
-  int reactivateByUserId(@Param("userId") Long userId);
+  @Query("SELECT t FROM Thread t WHERE t.user.id = :userId AND t.deactivatedAt IS NOT NULL")
+  List<Thread> findDeactivatedThreadsByUserId(@Param("userId") Long userId);
+
 }

--- a/src/main/java/org/nodystudio/nodybackend/service/comment/CommentService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/comment/CommentService.java
@@ -25,6 +25,7 @@ import org.nodystudio.nodybackend.exception.custom.UserNotFoundException;
 import org.nodystudio.nodybackend.repository.CommentRepository;
 import org.nodystudio.nodybackend.repository.ThreadRepository;
 import org.nodystudio.nodybackend.repository.UserRepository;
+import org.nodystudio.nodybackend.util.LoggingUtils;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -345,5 +346,43 @@ public class CommentService {
     eventPublisher.publishEvent(event);
     log.info("멘션 알림 이벤트 발행 - 댓글: {}, 멘션된 사용자: {}명",
         comment.getId(), mentionedUsers.size());
+  }
+
+  /**
+   * 특정 사용자의 모든 활성 댓글을 비활성화합니다.
+   * 계정 탈퇴 시 사용자 생성 데이터를 안전하게 보존하면서 조회에서 제외시킵니다.
+   *
+   * @param userId 비활성화할 사용자 ID
+   * @return 비활성화된 댓글의 개수
+   */
+  @Transactional
+  public int deactivateCommentsByUserId(Long userId) {
+    log.debug("사용자 댓글 비활성화 시작: userId={}", LoggingUtils.maskUserId(userId));
+
+    int deactivatedCount = commentRepository.deactivateByUserId(userId);
+
+    log.debug("사용자 댓글 비활성화 완료: userId={}, count={}", 
+            LoggingUtils.maskUserId(userId), deactivatedCount);
+
+    return deactivatedCount;
+  }
+
+  /**
+   * 특정 사용자의 모든 비활성화된 댓글을 재활성화합니다.
+   * 계정 복구 시 다시 조회 가능하도록 복원합니다.
+   *
+   * @param userId 재활성화할 사용자 ID
+   * @return 재활성화된 댓글의 개수
+   */
+  @Transactional
+  public int reactivateCommentsByUserId(Long userId) {
+    log.debug("사용자 댓글 재활성화 시작: userId={}", LoggingUtils.maskUserId(userId));
+
+    int reactivatedCount = commentRepository.reactivateByUserId(userId);
+
+    log.debug("사용자 댓글 재활성화 완료: userId={}, count={}", 
+            LoggingUtils.maskUserId(userId), reactivatedCount);
+
+    return reactivatedCount;
   }
 }

--- a/src/main/java/org/nodystudio/nodybackend/service/like/LikeService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/like/LikeService.java
@@ -13,6 +13,7 @@ import org.nodystudio.nodybackend.repository.LikeRepository;
 import org.nodystudio.nodybackend.repository.LogRepository;
 import org.nodystudio.nodybackend.repository.ThreadRepository;
 import org.nodystudio.nodybackend.repository.UserRepository;
+import org.nodystudio.nodybackend.util.LoggingUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -178,5 +179,43 @@ public class LikeService {
       default:
         throw new IllegalArgumentException("지원하지 않는 대상 타입입니다: " + targetType);
     }
+  }
+
+  /**
+   * 특정 사용자의 모든 활성 좋아요를 비활성화합니다.
+   * 계정 탈퇴 시 사용자 생성 데이터를 안전하게 보존하면서 조회에서 제외시킵니다.
+   *
+   * @param userId 비활성화할 사용자 ID
+   * @return 비활성화된 좋아요의 개수
+   */
+  @Transactional
+  public int deactivateLikesByUserId(Long userId) {
+    log.debug("사용자 좋아요 비활성화 시작: userId={}", LoggingUtils.maskUserId(userId));
+
+    int deactivatedCount = likeRepository.deactivateByUserId(userId);
+
+    log.debug("사용자 좋아요 비활성화 완료: userId={}, count={}", 
+            LoggingUtils.maskUserId(userId), deactivatedCount);
+
+    return deactivatedCount;
+  }
+
+  /**
+   * 특정 사용자의 모든 비활성화된 좋아요를 재활성화합니다.
+   * 계정 복구 시 다시 조회 가능하도록 복원합니다.
+   *
+   * @param userId 재활성화할 사용자 ID
+   * @return 재활성화된 좋아요의 개수
+   */
+  @Transactional
+  public int reactivateLikesByUserId(Long userId) {
+    log.debug("사용자 좋아요 재활성화 시작: userId={}", LoggingUtils.maskUserId(userId));
+
+    int reactivatedCount = likeRepository.reactivateByUserId(userId);
+
+    log.debug("사용자 좋아요 재활성화 완료: userId={}, count={}", 
+            LoggingUtils.maskUserId(userId), reactivatedCount);
+
+    return reactivatedCount;
   }
 }

--- a/src/main/java/org/nodystudio/nodybackend/service/log/LogService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/log/LogService.java
@@ -14,12 +14,15 @@ import org.nodystudio.nodybackend.exception.custom.UserNotFoundException;
 import org.nodystudio.nodybackend.repository.LogRepository;
 import org.nodystudio.nodybackend.repository.UserRepository;
 import org.nodystudio.nodybackend.util.LocationUtils;
+import org.nodystudio.nodybackend.util.LoggingUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 /**
  * 사용자의 위치 기반 로그 관리 서비스
@@ -348,5 +351,47 @@ public class LogService {
     if (request.getMediaUrls() != null) {
       logEntity.updateMediaUrls(request.getMediaUrls());
     }
+  }
+
+  /**
+   * 특정 사용자의 모든 활성 로그를 비활성화합니다.
+   * 계정 탈퇴 시 사용자 생성 데이터를 안전하게 보존하면서 조회에서 제외시킵니다.
+   *
+   * @param userId 비활성화할 사용자 ID
+   * @return 비활성화된 로그의 개수
+   */
+  @Transactional
+  public int deactivateLogsByUserId(Long userId) {
+    log.debug("사용자 로그 비활성화 시작: userId={}", LoggingUtils.maskUserId(userId));
+
+    List<Log> activeLogs = logRepository.findActiveLogsByUserId(userId);
+    activeLogs.forEach(Log::deactivate);
+    logRepository.saveAll(activeLogs);
+
+    log.debug("사용자 로그 비활성화 완료: userId={}, count={}", 
+            LoggingUtils.maskUserId(userId), activeLogs.size());
+
+    return activeLogs.size();
+  }
+
+  /**
+   * 특정 사용자의 모든 비활성화된 로그를 재활성화합니다.
+   * 계정 복구 시 원본 공개설정을 보존하면서 다시 조회 가능하도록 복원합니다.
+   *
+   * @param userId 재활성화할 사용자 ID
+   * @return 재활성화된 로그의 개수
+   */
+  @Transactional
+  public int reactivateLogsByUserId(Long userId) {
+    log.debug("사용자 로그 재활성화 시작: userId={}", LoggingUtils.maskUserId(userId));
+
+    List<Log> deactivatedLogs = logRepository.findDeactivatedLogsByUserId(userId);
+    deactivatedLogs.forEach(Log::reactivate);
+    logRepository.saveAll(deactivatedLogs);
+
+    log.debug("사용자 로그 재활성화 완료: userId={}, count={}", 
+            LoggingUtils.maskUserId(userId), deactivatedLogs.size());
+
+    return deactivatedLogs.size();
   }
 }

--- a/src/main/java/org/nodystudio/nodybackend/service/thread/ThreadService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/thread/ThreadService.java
@@ -15,11 +15,14 @@ import org.nodystudio.nodybackend.exception.custom.UserNotFoundException;
 import org.nodystudio.nodybackend.repository.LogRepository;
 import org.nodystudio.nodybackend.repository.ThreadRepository;
 import org.nodystudio.nodybackend.repository.UserRepository;
+import org.nodystudio.nodybackend.util.LoggingUtils;
 import org.nodystudio.nodybackend.util.PageableUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 /**
  * 스레드 관리 서비스
@@ -280,5 +283,47 @@ public class ThreadService {
       Log newLog = validateAndGetLinkedLog(request.getLogId(), user);
       thread.connectToLog(newLog);
     }
+  }
+
+  /**
+   * 특정 사용자의 모든 활성 스레드를 비활성화합니다.
+   * 계정 탈퇴 시 사용자 생성 데이터를 안전하게 보존하면서 조회에서 제외시킵니다.
+   *
+   * @param userId 비활성화할 사용자 ID
+   * @return 비활성화된 스레드의 개수
+   */
+  @Transactional
+  public int deactivateThreadsByUserId(Long userId) {
+    log.debug("사용자 스레드 비활성화 시작: userId={}", LoggingUtils.maskUserId(userId));
+
+    List<Thread> activeThreads = threadRepository.findActiveThreadsByUserId(userId);
+    activeThreads.forEach(Thread::deactivate);
+    threadRepository.saveAll(activeThreads);
+
+    log.debug("사용자 스레드 비활성화 완료: userId={}, count={}", 
+            LoggingUtils.maskUserId(userId), activeThreads.size());
+
+    return activeThreads.size();
+  }
+
+  /**
+   * 특정 사용자의 모든 비활성화된 스레드를 재활성화합니다.
+   * 계정 복구 시 원본 공개설정을 보존하면서 다시 조회 가능하도록 복원합니다.
+   *
+   * @param userId 재활성화할 사용자 ID
+   * @return 재활성화된 스레드의 개수
+   */
+  @Transactional
+  public int reactivateThreadsByUserId(Long userId) {
+    log.debug("사용자 스레드 재활성화 시작: userId={}", LoggingUtils.maskUserId(userId));
+
+    List<Thread> deactivatedThreads = threadRepository.findDeactivatedThreadsByUserId(userId);
+    deactivatedThreads.forEach(Thread::reactivate);
+    threadRepository.saveAll(deactivatedThreads);
+
+    log.debug("사용자 스레드 재활성화 완료: userId={}, count={}", 
+            LoggingUtils.maskUserId(userId), deactivatedThreads.size());
+
+    return deactivatedThreads.size();
   }
 }

--- a/src/main/java/org/nodystudio/nodybackend/service/user/UserService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/user/UserService.java
@@ -6,7 +6,12 @@ import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.dto.user.UpdateNicknameRequestDto;
 import org.nodystudio.nodybackend.dto.user.UserDetailResponseDto;
 import org.nodystudio.nodybackend.exception.custom.AccountAlreadyDeactivatedException;
+import org.nodystudio.nodybackend.exception.custom.DuplicateNicknameException;
 import org.nodystudio.nodybackend.exception.custom.UserNotFoundException;
+import org.nodystudio.nodybackend.repository.CommentRepository;
+import org.nodystudio.nodybackend.repository.LikeRepository;
+import org.nodystudio.nodybackend.repository.LogRepository;
+import org.nodystudio.nodybackend.repository.ThreadRepository;
 import org.nodystudio.nodybackend.repository.UserRepository;
 import org.nodystudio.nodybackend.util.LoggingUtils;
 import org.springframework.stereotype.Service;
@@ -19,6 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
   private final UserRepository userRepository;
+  private final LogRepository logRepository;
+  private final ThreadRepository threadRepository;
+  private final CommentRepository commentRepository;
+  private final LikeRepository likeRepository;
 
   public UserDetailResponseDto getCurrentUser(String userId) {
     User user = findUserById(userId);
@@ -33,6 +42,14 @@ public class UserService {
     log.debug("닉네임 변경 상세: 기존닉네임={}, 새닉네임={}",
         LoggingUtils.maskNickname(user.getNickname()),
         LoggingUtils.maskNickname(requestDto.getNickname()));
+
+    // 닉네임 중복 검증 (본인 제외)
+    if (userRepository.existsByNicknameAndIdNotAndIsActiveTrue(requestDto.getNickname(),
+        user.getId())) {
+      log.warn("닉네임 중복 시도: userId={}, nickname={}",
+          LoggingUtils.maskUserId(userId), LoggingUtils.maskNickname(requestDto.getNickname()));
+      throw new DuplicateNicknameException("이미 사용 중인 닉네임입니다: " + requestDto.getNickname());
+    }
 
     user.updateNickname(requestDto.getNickname());
 
@@ -59,8 +76,8 @@ public class UserService {
         LoggingUtils.maskEmail(user.getEmail()),
         LoggingUtils.maskNickname(user.getNickname()));
 
-    // 1. 사용자 생성 데이터 삭제 (현재는 User만 존재, 추후 Log/Thread/Comment 추가 시 확장)
-    deleteUserGeneratedData(user);
+    // 1. 사용자 생성 데이터 비활성화 (Soft Delete)
+    deactivateUserGeneratedData(user);
 
     // 2. 계정 비활성화
     user.deactivateAccount();
@@ -73,23 +90,32 @@ public class UserService {
    *
    * @param user 탈퇴하는 사용자
    */
-  private void deleteUserGeneratedData(User user) {
+  private void deactivateUserGeneratedData(User user) {
     log.debug("사용자 생성 데이터 비활성화 시작: userId={}", LoggingUtils.maskUserId(user.getId()));
 
-    // TODO: 아래 엔티티들이 구현되면 주석 해제
-    // 1. Log 비활성화 (isVisible = false 설정)
-    // logRepository.deactivateByUserId(user.getUserId());
+    // 1. Log 비활성화 (deactivatedAt timestamp 설정)
+    int deactivatedLogs = logRepository.deactivateByUserId(user.getId());
+    log.debug("로그 비활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
+        deactivatedLogs);
 
-    // 2. Thread 비활성화 (isPublic = false로 변경)
-    // threadRepository.deactivateByUserId(user.getUserId());
+    // 2. Thread 비활성화 (deactivatedAt timestamp 설정)
+    int deactivatedThreads = threadRepository.deactivateByUserId(user.getId());
+    log.debug("스레드 비활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
+        deactivatedThreads);
 
     // 3. Comment 비활성화 (soft delete)
-    // commentRepository.deactivateByUserId(user.getUserId());
+    int deactivatedComments = commentRepository.deactivateByUserId(user.getId());
+    log.debug("댓글 비활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
+        deactivatedComments);
 
     // 4. 좋아요 비활성화 (soft delete)
-    // likeRepository.deactivateByUserId(user.getUserId());
+    int deactivatedLikes = likeRepository.deactivateByUserId(user.getId());
+    log.debug("좋아요 비활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
+        deactivatedLikes);
 
-    log.debug("사용자 생성 데이터 비활성화 완료: userId={}", LoggingUtils.maskUserId(user.getId()));
+    log.info("사용자 생성 데이터 비활성화 완료: userId={}, logs={}, threads={}, comments={}, likes={}",
+        LoggingUtils.maskUserId(user.getId()), deactivatedLogs, deactivatedThreads,
+        deactivatedComments, deactivatedLikes);
   }
 
   /**
@@ -100,20 +126,29 @@ public class UserService {
   public void reactivateUserGeneratedData(User user) {
     log.debug("사용자 생성 데이터 재활성화 시작: userId={}", LoggingUtils.maskUserId(user.getId()));
 
-    // TODO: 아래 엔티티들이 구현되면 주석 해제
-    // 1. Log 재활성화 (isVisible = true 설정)
-    // logRepository.reactivateByUserId(user.getUserId());
+    // 1. Log 재활성화 (deactivatedAt을 NULL로 설정)
+    int reactivatedLogs = logRepository.reactivateByUserId(user.getId());
+    log.debug("로그 재활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
+        reactivatedLogs);
 
-    // 2. Thread 재활성화 (원래 공개 설정으로 복원)
-    // threadRepository.reactivateByUserId(user.getUserId());
+    // 2. Thread 재활성화 (deactivatedAt을 NULL로 설정)
+    int reactivatedThreads = threadRepository.reactivateByUserId(user.getId());
+    log.debug("스레드 재활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
+        reactivatedThreads);
 
     // 3. Comment 재활성화
-    // commentRepository.reactivateByUserId(user.getUserId());
+    int reactivatedComments = commentRepository.reactivateByUserId(user.getId());
+    log.debug("댓글 재활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
+        reactivatedComments);
 
     // 4. 좋아요 데이터 재활성화
-    // likeRepository.reactivateByUserId(user.getUserId());
+    int reactivatedLikes = likeRepository.reactivateByUserId(user.getId());
+    log.debug("좋아요 재활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
+        reactivatedLikes);
 
-    log.debug("사용자 생성 데이터 재활성화 완료: userId={}", LoggingUtils.maskUserId(user.getId()));
+    log.info("사용자 생성 데이터 재활성화 완료: userId={}, logs={}, threads={}, comments={}, likes={}",
+        LoggingUtils.maskUserId(user.getId()), reactivatedLogs, reactivatedThreads,
+        reactivatedComments, reactivatedLikes);
   }
 
   /**
@@ -125,21 +160,7 @@ public class UserService {
    * @throws IllegalArgumentException 사용자 ID가 유효하지 않은 경우
    */
   private User findUserById(String userId) {
-    if (userId == null || userId.trim().isEmpty()) {
-      throw new IllegalArgumentException("사용자 ID는 필수입니다.");
-    }
-
-    Long userIdLong;
-    try {
-      userIdLong = Long.parseLong(userId.trim());
-    } catch (NumberFormatException e) {
-      throw new IllegalArgumentException("유효하지 않은 사용자 ID 형식입니다: " + userId);
-    }
-
-    if (userIdLong <= 0) {
-      throw new IllegalArgumentException("사용자 ID는 양수여야 합니다: " + userId);
-    }
-
+    Long userIdLong = parseAndValidateUserId(userId);
     return userRepository.findByIdAndIsActiveTrue(userIdLong)
         .orElseThrow(() -> UserNotFoundException.byUserId(userId));
   }
@@ -153,6 +174,19 @@ public class UserService {
    * @throws IllegalArgumentException 사용자 ID가 유효하지 않은 경우
    */
   private User findUserByIdIncludingInactive(String userId) {
+    Long userIdLong = parseAndValidateUserId(userId);
+    return userRepository.findById(userIdLong)
+        .orElseThrow(() -> UserNotFoundException.byUserId(userId));
+  }
+
+  /**
+   * 사용자 ID 문자열을 파싱하고 유효성을 검증합니다.
+   *
+   * @param userId 사용자 ID (문자열)
+   * @return 파싱된 사용자 ID (Long)
+   * @throws IllegalArgumentException 사용자 ID가 유효하지 않은 경우
+   */
+  private Long parseAndValidateUserId(String userId) {
     if (userId == null || userId.trim().isEmpty()) {
       throw new IllegalArgumentException("사용자 ID는 필수입니다.");
     }
@@ -168,7 +202,6 @@ public class UserService {
       throw new IllegalArgumentException("사용자 ID는 양수여야 합니다: " + userId);
     }
 
-    return userRepository.findById(userIdLong)
-        .orElseThrow(() -> UserNotFoundException.byUserId(userId));
+    return userIdLong;
   }
 }

--- a/src/main/java/org/nodystudio/nodybackend/service/user/UserService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/user/UserService.java
@@ -10,9 +10,9 @@ import org.nodystudio.nodybackend.exception.custom.DuplicateNicknameException;
 import org.nodystudio.nodybackend.exception.custom.UserNotFoundException;
 import org.nodystudio.nodybackend.repository.CommentRepository;
 import org.nodystudio.nodybackend.repository.LikeRepository;
-import org.nodystudio.nodybackend.repository.LogRepository;
-import org.nodystudio.nodybackend.repository.ThreadRepository;
 import org.nodystudio.nodybackend.repository.UserRepository;
+import org.nodystudio.nodybackend.service.log.LogService;
+import org.nodystudio.nodybackend.service.thread.ThreadService;
 import org.nodystudio.nodybackend.util.LoggingUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,8 +24,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
   private final UserRepository userRepository;
-  private final LogRepository logRepository;
-  private final ThreadRepository threadRepository;
+  private final LogService logService;
+  private final ThreadService threadService;
   private final CommentRepository commentRepository;
   private final LikeRepository likeRepository;
 
@@ -93,13 +93,13 @@ public class UserService {
   private void deactivateUserGeneratedData(User user) {
     log.debug("사용자 생성 데이터 비활성화 시작: userId={}", LoggingUtils.maskUserId(user.getId()));
 
-    // 1. Log 비활성화 (deactivatedAt timestamp 설정)
-    int deactivatedLogs = logRepository.deactivateByUserId(user.getId());
+    // 1. 사용자 로그를 비활성화하여 조회에서 제외 (원본 공개설정 보존)
+    int deactivatedLogs = logService.deactivateLogsByUserId(user.getId());
     log.debug("로그 비활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
         deactivatedLogs);
 
-    // 2. Thread 비활성화 (deactivatedAt timestamp 설정)
-    int deactivatedThreads = threadRepository.deactivateByUserId(user.getId());
+    // 2. 사용자 스레드를 비활성화하여 조회에서 제외 (원본 공개설정 보존)
+    int deactivatedThreads = threadService.deactivateThreadsByUserId(user.getId());
     log.debug("스레드 비활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
         deactivatedThreads);
 
@@ -126,13 +126,13 @@ public class UserService {
   public void reactivateUserGeneratedData(User user) {
     log.debug("사용자 생성 데이터 재활성화 시작: userId={}", LoggingUtils.maskUserId(user.getId()));
 
-    // 1. Log 재활성화 (deactivatedAt을 NULL로 설정)
-    int reactivatedLogs = logRepository.reactivateByUserId(user.getId());
+    // 1. 사용자 로그를 재활성화하여 원본 공개설정으로 복원
+    int reactivatedLogs = logService.reactivateLogsByUserId(user.getId());
     log.debug("로그 재활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
         reactivatedLogs);
 
-    // 2. Thread 재활성화 (deactivatedAt을 NULL로 설정)
-    int reactivatedThreads = threadRepository.reactivateByUserId(user.getId());
+    // 2. 사용자 스레드를 재활성화하여 원본 공개설정으로 복원
+    int reactivatedThreads = threadService.reactivateThreadsByUserId(user.getId());
     log.debug("스레드 재활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
         reactivatedThreads);
 

--- a/src/main/java/org/nodystudio/nodybackend/service/user/UserService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/user/UserService.java
@@ -8,9 +8,9 @@ import org.nodystudio.nodybackend.dto.user.UserDetailResponseDto;
 import org.nodystudio.nodybackend.exception.custom.AccountAlreadyDeactivatedException;
 import org.nodystudio.nodybackend.exception.custom.DuplicateNicknameException;
 import org.nodystudio.nodybackend.exception.custom.UserNotFoundException;
-import org.nodystudio.nodybackend.repository.CommentRepository;
-import org.nodystudio.nodybackend.repository.LikeRepository;
 import org.nodystudio.nodybackend.repository.UserRepository;
+import org.nodystudio.nodybackend.service.comment.CommentService;
+import org.nodystudio.nodybackend.service.like.LikeService;
 import org.nodystudio.nodybackend.service.log.LogService;
 import org.nodystudio.nodybackend.service.thread.ThreadService;
 import org.nodystudio.nodybackend.util.LoggingUtils;
@@ -26,8 +26,8 @@ public class UserService {
   private final UserRepository userRepository;
   private final LogService logService;
   private final ThreadService threadService;
-  private final CommentRepository commentRepository;
-  private final LikeRepository likeRepository;
+  private final CommentService commentService;
+  private final LikeService likeService;
 
   public UserDetailResponseDto getCurrentUser(String userId) {
     User user = findUserById(userId);
@@ -103,13 +103,13 @@ public class UserService {
     log.debug("스레드 비활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
         deactivatedThreads);
 
-    // 3. Comment 비활성화 (soft delete)
-    int deactivatedComments = commentRepository.deactivateByUserId(user.getId());
+    // 3. 사용자 댓글을 비활성화하여 조회에서 제외
+    int deactivatedComments = commentService.deactivateCommentsByUserId(user.getId());
     log.debug("댓글 비활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
         deactivatedComments);
 
-    // 4. 좋아요 비활성화 (soft delete)
-    int deactivatedLikes = likeRepository.deactivateByUserId(user.getId());
+    // 4. 사용자 좋아요를 비활성화하여 조회에서 제외
+    int deactivatedLikes = likeService.deactivateLikesByUserId(user.getId());
     log.debug("좋아요 비활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
         deactivatedLikes);
 
@@ -136,13 +136,13 @@ public class UserService {
     log.debug("스레드 재활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
         reactivatedThreads);
 
-    // 3. Comment 재활성화
-    int reactivatedComments = commentRepository.reactivateByUserId(user.getId());
+    // 3. 사용자 댓글을 재활성화하여 다시 조회 가능하도록 복원
+    int reactivatedComments = commentService.reactivateCommentsByUserId(user.getId());
     log.debug("댓글 재활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
         reactivatedComments);
 
-    // 4. 좋아요 데이터 재활성화
-    int reactivatedLikes = likeRepository.reactivateByUserId(user.getId());
+    // 4. 사용자 좋아요를 재활성화하여 다시 조회 가능하도록 복원
+    int reactivatedLikes = likeService.reactivateLikesByUserId(user.getId());
     log.debug("좋아요 재활성화 완료: userId={}, count={}", LoggingUtils.maskUserId(user.getId()),
         reactivatedLikes);
 

--- a/src/test/java/org/nodystudio/nodybackend/domain/log/LogTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/domain/log/LogTest.java
@@ -1,0 +1,340 @@
+package org.nodystudio.nodybackend.domain.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nodystudio.nodybackend.domain.enums.OAuthProvider;
+import org.nodystudio.nodybackend.domain.user.RoleType;
+import org.nodystudio.nodybackend.domain.user.User;
+
+@DisplayName("Log 도메인 엔티티 테스트")
+class LogTest {
+
+  private User testUser;
+  private User otherUser;
+  private Log log;
+
+  @BeforeEach
+  void setUp() {
+    testUser = User.builder()
+        .id(1L)
+        .email("test@example.com")
+        .nickname("testuser")
+        .provider(OAuthProvider.GOOGLE)
+        .socialId("12345")
+        .role(RoleType.USER)
+        .build();
+
+    otherUser = User.builder()
+        .id(2L)
+        .email("other@example.com")
+        .nickname("otheruser")
+        .provider(OAuthProvider.GOOGLE)
+        .socialId("67890")
+        .role(RoleType.USER)
+        .build();
+
+    log = Log.builder()
+        .id(1L)
+        .user(testUser)
+        .content("테스트 로그 내용")
+        .latitude(new BigDecimal("37.5665"))
+        .longitude(new BigDecimal("126.9780"))
+        .address("서울특별시 중구 세종대로 110")
+        .mediaUrls(new ArrayList<>())
+        .isPublic(true)
+        .viewCount(0L)
+        .build();
+  }
+
+  @Test
+  @DisplayName("내용 업데이트 성공")
+  void updateContent_Success() {
+    // given
+    String newContent = "새로운 로그 내용";
+
+    // when
+    log.updateContent(newContent);
+
+    // then
+    assertThat(log.getContent()).isEqualTo(newContent);
+  }
+
+  @Test
+  @DisplayName("위치 정보 업데이트 성공")
+  void updateLocation_Success() {
+    // given
+    BigDecimal newLatitude = new BigDecimal("35.1796");
+    BigDecimal newLongitude = new BigDecimal("129.0756");
+    String newAddress = "부산광역시 해운대구";
+
+    // when
+    log.updateLocation(newLatitude, newLongitude, newAddress);
+
+    // then
+    assertThat(log.getLatitude()).isEqualTo(newLatitude);
+    assertThat(log.getLongitude()).isEqualTo(newLongitude);
+    assertThat(log.getAddress()).isEqualTo(newAddress);
+  }
+
+  @Test
+  @DisplayName("공개 설정 업데이트 성공")
+  void updatePublicSetting_Success() {
+    // given
+    assertThat(log.getIsPublic()).isTrue();
+
+    // when
+    log.updatePublicSetting(false);
+
+    // then
+    assertThat(log.getIsPublic()).isFalse();
+  }
+
+  @Test
+  @DisplayName("미디어 URL 목록 업데이트 성공")
+  void updateMediaUrls_Success() {
+    // given
+    List<String> newMediaUrls = List.of(
+        "https://example.com/image1.jpg",
+        "https://example.com/image2.jpg"
+    );
+
+    // when
+    log.updateMediaUrls(newMediaUrls);
+
+    // then
+    assertThat(log.getMediaUrls()).hasSize(2);
+    assertThat(log.getMediaUrls()).containsExactly(
+        "https://example.com/image1.jpg",
+        "https://example.com/image2.jpg"
+    );
+  }
+
+  @Test
+  @DisplayName("미디어 URL null로 업데이트 시 빈 리스트로 설정")
+  void updateMediaUrls_NullList_ClearsUrls() {
+    // given
+    log.getMediaUrls().add("https://example.com/image.jpg");
+    assertThat(log.getMediaUrls()).hasSize(1);
+
+    // when
+    log.updateMediaUrls(null);
+
+    // then
+    assertThat(log.getMediaUrls()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("조회수 증가 성공")
+  void incrementViewCount_Success() {
+    // given
+    long initialViewCount = log.getViewCount();
+
+    // when
+    log.incrementViewCount();
+
+    // then
+    assertThat(log.getViewCount()).isEqualTo(initialViewCount + 1);
+  }
+
+  @Test
+  @DisplayName("조회수 여러 번 증가")
+  void incrementViewCount_Multiple_Success() {
+    // given
+    long initialViewCount = log.getViewCount();
+
+    // when
+    log.incrementViewCount();
+    log.incrementViewCount();
+    log.incrementViewCount();
+
+    // then
+    assertThat(log.getViewCount()).isEqualTo(initialViewCount + 3);
+  }
+
+  @Test
+  @DisplayName("로그 소유자 확인 - 본인인 경우")
+  void isOwnedBy_OwnLog_ReturnsTrue() {
+    // when & then
+    assertThat(log.isOwnedBy(testUser)).isTrue();
+  }
+
+  @Test
+  @DisplayName("로그 소유자 확인 - 다른 사용자인 경우")
+  void isOwnedBy_OtherUser_ReturnsFalse() {
+    // when & then
+    assertThat(log.isOwnedBy(otherUser)).isFalse();
+  }
+
+  @Test
+  @DisplayName("로그 소유자 확인 - null 사용자인 경우")
+  void isOwnedBy_NullUser_ReturnsFalse() {
+    // when & then
+    assertThat(log.isOwnedBy(null)).isFalse();
+  }
+
+  @Test
+  @DisplayName("로그 소유자 확인 - 로그 사용자가 null인 경우")
+  void isOwnedBy_LogUserIsNull_ReturnsFalse() {
+    // given
+    Log logWithNullUser = Log.builder()
+        .id(2L)
+        .user(null)
+        .content("내용")
+        .build();
+
+    // when & then
+    assertThat(logWithNullUser.isOwnedBy(testUser)).isFalse();
+  }
+
+  @Test
+  @DisplayName("공개 로그 조회 권한 확인 - 익명 사용자")
+  void isViewableBy_PublicLog_AnonymousUser_ReturnsTrue() {
+    // given
+    assertThat(log.getIsPublic()).isTrue();
+
+    // when & then
+    assertThat(log.isViewableBy(null)).isTrue();
+  }
+
+  @Test
+  @DisplayName("공개 로그 조회 권한 확인 - 다른 사용자")
+  void isViewableBy_PublicLog_OtherUser_ReturnsTrue() {
+    // given
+    assertThat(log.getIsPublic()).isTrue();
+
+    // when & then
+    assertThat(log.isViewableBy(otherUser)).isTrue();
+  }
+
+  @Test
+  @DisplayName("비공개 로그 조회 권한 확인 - 작성자")
+  void isViewableBy_PrivateLog_Owner_ReturnsTrue() {
+    // given
+    log.updatePublicSetting(false);
+
+    // when & then
+    assertThat(log.isViewableBy(testUser)).isTrue();
+  }
+
+  @Test
+  @DisplayName("비공개 로그 조회 권한 확인 - 다른 사용자")
+  void isViewableBy_PrivateLog_OtherUser_ReturnsFalse() {
+    // given
+    log.updatePublicSetting(false);
+
+    // when & then
+    assertThat(log.isViewableBy(otherUser)).isFalse();
+  }
+
+  @Test
+  @DisplayName("비공개 로그 조회 권한 확인 - 익명 사용자")
+  void isViewableBy_PrivateLog_AnonymousUser_ReturnsFalse() {
+    // given
+    log.updatePublicSetting(false);
+
+    // when & then
+    assertThat(log.isViewableBy(null)).isFalse();
+  }
+
+  @Test
+  @DisplayName("빌더 패턴으로 로그 생성 - 기본값 확인")
+  void builder_DefaultValues_Success() {
+    // when
+    Log logWithDefaults = Log.builder()
+        .user(testUser)
+        .content("기본값 테스트")
+        .build();
+
+    // then
+    assertThat(logWithDefaults.getIsPublic()).isTrue();
+    assertThat(logWithDefaults.getViewCount()).isZero();
+    assertThat(logWithDefaults.getMediaUrls()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("로그 비활성화 - 성공")
+  void deactivate_Success() {
+    // given
+    assertThat(log.isActive()).isTrue();
+    assertThat(log.isDeactivated()).isFalse();
+
+    // when
+    log.deactivate();
+
+    // then
+    assertThat(log.isActive()).isFalse();
+    assertThat(log.isDeactivated()).isTrue();
+    assertThat(log.getDeactivatedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("로그 재활성화 - 성공")
+  void reactivate_Success() {
+    // given
+    log.deactivate();
+    assertThat(log.isDeactivated()).isTrue();
+
+    // when
+    log.reactivate();
+
+    // then
+    assertThat(log.isActive()).isTrue();
+    assertThat(log.isDeactivated()).isFalse();
+    assertThat(log.getDeactivatedAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("활성 로그 상태 확인")
+  void isActive_ActiveLog_ReturnsTrue() {
+    // given & when & then
+    assertThat(log.isActive()).isTrue();
+    assertThat(log.isDeactivated()).isFalse();
+  }
+
+  @Test
+  @DisplayName("비활성 로그 상태 확인")
+  void isDeactivated_DeactivatedLog_ReturnsTrue() {
+    // given
+    log.deactivate();
+
+    // when & then
+    assertThat(log.isDeactivated()).isTrue();
+    assertThat(log.isActive()).isFalse();
+  }
+
+  @Test
+  @DisplayName("비활성화된 로그의 원본 공개설정 보존 확인")
+  void deactivate_PreservesOriginalPublicSetting() {
+    // given
+    log.updatePublicSetting(false); // 비공개로 설정
+    assertThat(log.getIsPublic()).isFalse();
+
+    // when
+    log.deactivate();
+
+    // then
+    assertThat(log.getIsPublic()).isFalse(); // 원본 설정 보존
+    assertThat(log.isDeactivated()).isTrue();
+  }
+
+  @Test
+  @DisplayName("재활성화된 로그의 원본 공개설정 보존 확인")
+  void reactivate_PreservesOriginalPublicSetting() {
+    // given
+    log.updatePublicSetting(false); // 비공개로 설정
+    log.deactivate();
+    
+    // when
+    log.reactivate();
+
+    // then
+    assertThat(log.getIsPublic()).isFalse(); // 원본 설정 보존
+    assertThat(log.isActive()).isTrue();
+  }
+}

--- a/src/test/java/org/nodystudio/nodybackend/domain/thread/ThreadTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/domain/thread/ThreadTest.java
@@ -468,4 +468,85 @@ class ThreadTest {
     assertThat(thread.getComments()).doesNotContain(comment);
     assertThat(comment.getThread()).isEqualTo(otherThread); // 다른 스레드 유지
   }
+
+  @Test
+  @DisplayName("스레드 비활성화 - 성공")
+  void deactivate_Success() {
+    // given
+    assertThat(thread.isActive()).isTrue();
+    assertThat(thread.isDeactivated()).isFalse();
+
+    // when
+    thread.deactivate();
+
+    // then
+    assertThat(thread.isActive()).isFalse();
+    assertThat(thread.isDeactivated()).isTrue();
+    assertThat(thread.getDeactivatedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("스레드 재활성화 - 성공")
+  void reactivate_Success() {
+    // given
+    thread.deactivate();
+    assertThat(thread.isDeactivated()).isTrue();
+
+    // when
+    thread.reactivate();
+
+    // then
+    assertThat(thread.isActive()).isTrue();
+    assertThat(thread.isDeactivated()).isFalse();
+    assertThat(thread.getDeactivatedAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("활성 스레드 상태 확인")
+  void isActive_ActiveThread_ReturnsTrue() {
+    // given & when & then
+    assertThat(thread.isActive()).isTrue();
+    assertThat(thread.isDeactivated()).isFalse();
+  }
+
+  @Test
+  @DisplayName("비활성 스레드 상태 확인")
+  void isDeactivated_DeactivatedThread_ReturnsTrue() {
+    // given
+    thread.deactivate();
+
+    // when & then
+    assertThat(thread.isDeactivated()).isTrue();
+    assertThat(thread.isActive()).isFalse();
+  }
+
+  @Test
+  @DisplayName("비활성화된 스레드의 원본 공개설정 보존 확인")
+  void deactivate_PreservesOriginalPublicSetting() {
+    // given
+    thread.updatePublicSetting(false); // 비공개로 설정
+    assertThat(thread.getIsPublic()).isFalse();
+
+    // when
+    thread.deactivate();
+
+    // then
+    assertThat(thread.getIsPublic()).isFalse(); // 원본 설정 보존
+    assertThat(thread.isDeactivated()).isTrue();
+  }
+
+  @Test
+  @DisplayName("재활성화된 스레드의 원본 공개설정 보존 확인")
+  void reactivate_PreservesOriginalPublicSetting() {
+    // given
+    thread.updatePublicSetting(false); // 비공개로 설정
+    thread.deactivate();
+    
+    // when
+    thread.reactivate();
+
+    // then
+    assertThat(thread.getIsPublic()).isFalse(); // 원본 설정 보존
+    assertThat(thread.isActive()).isTrue();
+  }
 }

--- a/src/test/java/org/nodystudio/nodybackend/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/repository/UserRepositoryIntegrationTest.java
@@ -1,0 +1,129 @@
+package org.nodystudio.nodybackend.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nodystudio.nodybackend.domain.enums.OAuthProvider;
+import org.nodystudio.nodybackend.domain.user.RoleType;
+import org.nodystudio.nodybackend.domain.user.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@DisplayName("UserRepository 통합 테스트")
+class UserRepositoryIntegrationTest {
+
+  @Autowired
+  private TestEntityManager entityManager;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  private User testUser1;
+  private User testUser2;
+
+  @BeforeEach
+  void setUp() {
+    testUser1 = User.builder()
+        .provider(OAuthProvider.GOOGLE)
+        .socialId("123456789")
+        .email("user1@example.com")
+        .nickname("사용자1")
+        .role(RoleType.USER)
+        .isActive(true)
+        .build();
+
+    testUser2 = User.builder()
+        .provider(OAuthProvider.GOOGLE)
+        .socialId("987654321")
+        .email("user2@example.com")
+        .nickname("사용자2")
+        .role(RoleType.USER)
+        .isActive(true)
+        .build();
+
+    entityManager.persistAndFlush(testUser1);
+    entityManager.persistAndFlush(testUser2);
+  }
+
+  @Test
+  @DisplayName("닉네임 중복 검증 - 다른 사용자 제외 후 중복 확인")
+  void existsByNicknameAndIdNotAndIsActiveTrue_shouldReturnCorrectResult() {
+    // given
+    String existingNickname = "사용자2";
+    String newNickname = "새로운사용자";
+
+    // when - 다른 사용자의 닉네임을 사용하려고 할 때
+    boolean isDuplicate = userRepository.existsByNicknameAndIdNotAndIsActiveTrue(
+        existingNickname, testUser1.getId());
+
+    // then
+    assertThat(isDuplicate).isTrue();
+
+    // when - 존재하지 않는 닉네임을 사용하려고 할 때
+    boolean isNotDuplicate = userRepository.existsByNicknameAndIdNotAndIsActiveTrue(
+        newNickname, testUser1.getId());
+
+    // then
+    assertThat(isNotDuplicate).isFalse();
+
+    // when - 본인의 닉네임을 그대로 사용하려고 할 때
+    boolean isSameNickname = userRepository.existsByNicknameAndIdNotAndIsActiveTrue(
+        testUser1.getNickname(), testUser1.getId());
+
+    // then
+    assertThat(isSameNickname).isFalse();
+  }
+
+  @Test
+  @DisplayName("활성 사용자만 닉네임 존재 확인")
+  void existsByNicknameAndIsActiveTrue_shouldOnlyCheckActiveUsers() {
+    // given
+    String nickname = "사용자1";
+
+    // when - 활성 사용자의 닉네임 확인
+    boolean exists = userRepository.existsByNicknameAndIsActiveTrue(nickname);
+
+    // then
+    assertThat(exists).isTrue();
+
+    // given - 사용자를 비활성화
+    testUser1.deactivateAccount();
+    entityManager.persistAndFlush(testUser1);
+
+    // when - 비활성화된 사용자의 닉네임 확인
+    boolean existsAfterDeactivation = userRepository.existsByNicknameAndIsActiveTrue(nickname);
+
+    // then
+    assertThat(existsAfterDeactivation).isFalse();
+  }
+
+  @Test
+  @DisplayName("활성 사용자만 닉네임으로 조회")
+  void findByNicknameAndIsActiveTrue_shouldOnlyReturnActiveUsers() {
+    // given
+    String nickname = "사용자1";
+
+    // when - 활성 사용자 조회
+    var activeUser = userRepository.findByNicknameAndIsActiveTrue(nickname);
+
+    // then
+    assertThat(activeUser).isPresent();
+    assertThat(activeUser.get().getId()).isEqualTo(testUser1.getId());
+
+    // given - 사용자를 비활성화
+    testUser1.deactivateAccount();
+    entityManager.persistAndFlush(testUser1);
+
+    // when - 비활성화된 사용자 조회
+    var deactivatedUser = userRepository.findByNicknameAndIsActiveTrue(nickname);
+
+    // then
+    assertThat(deactivatedUser).isEmpty();
+  }
+}

--- a/src/test/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserServiceTest.java
@@ -107,13 +107,13 @@ class CustomOAuth2UserServiceTest {
 
     given(userRepository.findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE,
         "google_12345")).willReturn(
-            Optional.empty());
+        Optional.empty());
     given(userRepository.findByEmailAndDeletedAtAfter(anyString(),
         any(LocalDateTime.class))).willReturn(
-            Optional.empty());
+        Optional.empty());
     given(
         userRepository.findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345")).willReturn(
-            Optional.empty());
+        Optional.empty());
     given(userRepository.saveAndFlush(any(User.class))).willAnswer(invocation -> {
       User userToSave = invocation.getArgument(0);
 

--- a/src/test/java/org/nodystudio/nodybackend/service/user/UserServiceTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/service/user/UserServiceTest.java
@@ -21,9 +21,9 @@ import org.nodystudio.nodybackend.dto.user.UserDetailResponseDto;
 import org.nodystudio.nodybackend.exception.custom.AccountAlreadyDeactivatedException;
 import org.nodystudio.nodybackend.exception.custom.DuplicateNicknameException;
 import org.nodystudio.nodybackend.exception.custom.UserNotFoundException;
-import org.nodystudio.nodybackend.repository.CommentRepository;
-import org.nodystudio.nodybackend.repository.LikeRepository;
 import org.nodystudio.nodybackend.repository.UserRepository;
+import org.nodystudio.nodybackend.service.comment.CommentService;
+import org.nodystudio.nodybackend.service.like.LikeService;
 import org.nodystudio.nodybackend.service.log.LogService;
 import org.nodystudio.nodybackend.service.thread.ThreadService;
 
@@ -40,9 +40,9 @@ class UserServiceTest {
   @Mock
   private ThreadService threadService;
   @Mock
-  private CommentRepository commentRepository;
+  private CommentService commentService;
   @Mock
-  private LikeRepository likeRepository;
+  private LikeService likeService;
   @InjectMocks
   private UserService userService;
   private User testUser;
@@ -225,8 +225,8 @@ class UserServiceTest {
     given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(testUser));
     given(logService.deactivateLogsByUserId(TEST_USER_ID)).willReturn(5);
     given(threadService.deactivateThreadsByUserId(TEST_USER_ID)).willReturn(3);
-    given(commentRepository.deactivateByUserId(TEST_USER_ID)).willReturn(10);
-    given(likeRepository.deactivateByUserId(TEST_USER_ID)).willReturn(7);
+    given(commentService.deactivateCommentsByUserId(TEST_USER_ID)).willReturn(10);
+    given(likeService.deactivateLikesByUserId(TEST_USER_ID)).willReturn(7);
 
     // when
     userService.deactivateAccount(TEST_USER_ID_STRING);
@@ -239,8 +239,8 @@ class UserServiceTest {
     verify(userRepository).findById(TEST_USER_ID);
     verify(logService).deactivateLogsByUserId(TEST_USER_ID);
     verify(threadService).deactivateThreadsByUserId(TEST_USER_ID);
-    verify(commentRepository).deactivateByUserId(TEST_USER_ID);
-    verify(likeRepository).deactivateByUserId(TEST_USER_ID);
+    verify(commentService).deactivateCommentsByUserId(TEST_USER_ID);
+    verify(likeService).deactivateLikesByUserId(TEST_USER_ID);
   }
 
   @Test
@@ -300,8 +300,8 @@ class UserServiceTest {
     // given
     given(logService.reactivateLogsByUserId(TEST_USER_ID)).willReturn(5);
     given(threadService.reactivateThreadsByUserId(TEST_USER_ID)).willReturn(3);
-    given(commentRepository.reactivateByUserId(TEST_USER_ID)).willReturn(10);
-    given(likeRepository.reactivateByUserId(TEST_USER_ID)).willReturn(7);
+    given(commentService.reactivateCommentsByUserId(TEST_USER_ID)).willReturn(10);
+    given(likeService.reactivateLikesByUserId(TEST_USER_ID)).willReturn(7);
 
     // when
     userService.reactivateUserGeneratedData(testUser);
@@ -309,8 +309,8 @@ class UserServiceTest {
     // then
     verify(logService).reactivateLogsByUserId(TEST_USER_ID);
     verify(threadService).reactivateThreadsByUserId(TEST_USER_ID);
-    verify(commentRepository).reactivateByUserId(TEST_USER_ID);
-    verify(likeRepository).reactivateByUserId(TEST_USER_ID);
+    verify(commentService).reactivateCommentsByUserId(TEST_USER_ID);
+    verify(likeService).reactivateLikesByUserId(TEST_USER_ID);
   }
 
   @Test

--- a/src/test/java/org/nodystudio/nodybackend/service/user/UserServiceTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/service/user/UserServiceTest.java
@@ -23,9 +23,9 @@ import org.nodystudio.nodybackend.exception.custom.DuplicateNicknameException;
 import org.nodystudio.nodybackend.exception.custom.UserNotFoundException;
 import org.nodystudio.nodybackend.repository.CommentRepository;
 import org.nodystudio.nodybackend.repository.LikeRepository;
-import org.nodystudio.nodybackend.repository.LogRepository;
-import org.nodystudio.nodybackend.repository.ThreadRepository;
 import org.nodystudio.nodybackend.repository.UserRepository;
+import org.nodystudio.nodybackend.service.log.LogService;
+import org.nodystudio.nodybackend.service.thread.ThreadService;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("UserService 테스트")
@@ -36,9 +36,9 @@ class UserServiceTest {
   @Mock
   private UserRepository userRepository;
   @Mock
-  private LogRepository logRepository;
+  private LogService logService;
   @Mock
-  private ThreadRepository threadRepository;
+  private ThreadService threadService;
   @Mock
   private CommentRepository commentRepository;
   @Mock
@@ -223,8 +223,8 @@ class UserServiceTest {
   void deactivateAccount_success() {
     // given
     given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(testUser));
-    given(logRepository.deactivateByUserId(TEST_USER_ID)).willReturn(5);
-    given(threadRepository.deactivateByUserId(TEST_USER_ID)).willReturn(3);
+    given(logService.deactivateLogsByUserId(TEST_USER_ID)).willReturn(5);
+    given(threadService.deactivateThreadsByUserId(TEST_USER_ID)).willReturn(3);
     given(commentRepository.deactivateByUserId(TEST_USER_ID)).willReturn(10);
     given(likeRepository.deactivateByUserId(TEST_USER_ID)).willReturn(7);
 
@@ -237,8 +237,8 @@ class UserServiceTest {
     assertThat(testUser.getRefreshToken()).isNull();
     assertThat(testUser.getRefreshTokenExpiry()).isNull();
     verify(userRepository).findById(TEST_USER_ID);
-    verify(logRepository).deactivateByUserId(TEST_USER_ID);
-    verify(threadRepository).deactivateByUserId(TEST_USER_ID);
+    verify(logService).deactivateLogsByUserId(TEST_USER_ID);
+    verify(threadService).deactivateThreadsByUserId(TEST_USER_ID);
     verify(commentRepository).deactivateByUserId(TEST_USER_ID);
     verify(likeRepository).deactivateByUserId(TEST_USER_ID);
   }
@@ -298,8 +298,8 @@ class UserServiceTest {
   @DisplayName("사용자 생성 데이터 재활성화 - 성공")
   void reactivateUserGeneratedData_success() {
     // given
-    given(logRepository.reactivateByUserId(TEST_USER_ID)).willReturn(5);
-    given(threadRepository.reactivateByUserId(TEST_USER_ID)).willReturn(3);
+    given(logService.reactivateLogsByUserId(TEST_USER_ID)).willReturn(5);
+    given(threadService.reactivateThreadsByUserId(TEST_USER_ID)).willReturn(3);
     given(commentRepository.reactivateByUserId(TEST_USER_ID)).willReturn(10);
     given(likeRepository.reactivateByUserId(TEST_USER_ID)).willReturn(7);
 
@@ -307,8 +307,8 @@ class UserServiceTest {
     userService.reactivateUserGeneratedData(testUser);
 
     // then
-    verify(logRepository).reactivateByUserId(TEST_USER_ID);
-    verify(threadRepository).reactivateByUserId(TEST_USER_ID);
+    verify(logService).reactivateLogsByUserId(TEST_USER_ID);
+    verify(threadService).reactivateThreadsByUserId(TEST_USER_ID);
     verify(commentRepository).reactivateByUserId(TEST_USER_ID);
     verify(likeRepository).reactivateByUserId(TEST_USER_ID);
   }
@@ -317,7 +317,7 @@ class UserServiceTest {
   @DisplayName("사용자 생성 데이터 재활성화 - 재활성화 도중 오류 발생")
   void reactivateUserGeneratedData_exceptionDuringReactivation() {
     // given
-    given(logRepository.reactivateByUserId(TEST_USER_ID)).willThrow(
+    given(logService.reactivateLogsByUserId(TEST_USER_ID)).willThrow(
         new RuntimeException("Database error"));
 
     // when & then
@@ -325,6 +325,6 @@ class UserServiceTest {
         .isInstanceOf(RuntimeException.class)
         .hasMessage("Database error");
 
-    verify(logRepository).reactivateByUserId(TEST_USER_ID);
+    verify(logService).reactivateLogsByUserId(TEST_USER_ID);
   }
 }

--- a/src/test/java/org/nodystudio/nodybackend/service/user/UserServiceTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/service/user/UserServiceTest.java
@@ -19,7 +19,12 @@ import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.dto.user.UpdateNicknameRequestDto;
 import org.nodystudio.nodybackend.dto.user.UserDetailResponseDto;
 import org.nodystudio.nodybackend.exception.custom.AccountAlreadyDeactivatedException;
+import org.nodystudio.nodybackend.exception.custom.DuplicateNicknameException;
 import org.nodystudio.nodybackend.exception.custom.UserNotFoundException;
+import org.nodystudio.nodybackend.repository.CommentRepository;
+import org.nodystudio.nodybackend.repository.LikeRepository;
+import org.nodystudio.nodybackend.repository.LogRepository;
+import org.nodystudio.nodybackend.repository.ThreadRepository;
 import org.nodystudio.nodybackend.repository.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,6 +35,14 @@ class UserServiceTest {
   private final String TEST_USER_ID_STRING = "1";
   @Mock
   private UserRepository userRepository;
+  @Mock
+  private LogRepository logRepository;
+  @Mock
+  private ThreadRepository threadRepository;
+  @Mock
+  private CommentRepository commentRepository;
+  @Mock
+  private LikeRepository likeRepository;
   @InjectMocks
   private UserService userService;
   private User testUser;
@@ -81,6 +94,8 @@ class UserServiceTest {
     String newNickname = "새로운닉네임";
     UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto(newNickname);
     given(userRepository.findByIdAndIsActiveTrue(TEST_USER_ID)).willReturn(Optional.of(testUser));
+    given(userRepository.existsByNicknameAndIdNotAndIsActiveTrue(newNickname,
+        TEST_USER_ID)).willReturn(false);
 
     // when
     UserDetailResponseDto result = userService.updateNickname(TEST_USER_ID_STRING, requestDto);
@@ -89,6 +104,7 @@ class UserServiceTest {
     assertThat(result.getNickname()).isEqualTo(newNickname);
     assertThat(testUser.getNickname()).isEqualTo(newNickname);
     verify(userRepository).findByIdAndIsActiveTrue(TEST_USER_ID);
+    verify(userRepository).existsByNicknameAndIdNotAndIsActiveTrue(newNickname, TEST_USER_ID);
   }
 
   @Test
@@ -102,6 +118,25 @@ class UserServiceTest {
     assertThatThrownBy(() -> userService.updateNickname(TEST_USER_ID_STRING, requestDto))
         .isInstanceOf(UserNotFoundException.class)
         .hasMessageContaining("사용자 ID '1'로 사용자를 찾을 수 없습니다.");
+  }
+
+  @Test
+  @DisplayName("닉네임 변경 - 중복 닉네임")
+  void updateNickname_duplicateNickname() {
+    // given
+    String duplicateNickname = "이미존재하는닉네임";
+    UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto(duplicateNickname);
+    given(userRepository.findByIdAndIsActiveTrue(TEST_USER_ID)).willReturn(Optional.of(testUser));
+    given(userRepository.existsByNicknameAndIdNotAndIsActiveTrue(duplicateNickname,
+        TEST_USER_ID)).willReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> userService.updateNickname(TEST_USER_ID_STRING, requestDto))
+        .isInstanceOf(DuplicateNicknameException.class)
+        .hasMessageContaining("이미 사용 중인 닉네임입니다: " + duplicateNickname);
+
+    verify(userRepository).findByIdAndIsActiveTrue(TEST_USER_ID);
+    verify(userRepository).existsByNicknameAndIdNotAndIsActiveTrue(duplicateNickname, TEST_USER_ID);
   }
 
   @Test
@@ -188,6 +223,10 @@ class UserServiceTest {
   void deactivateAccount_success() {
     // given
     given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(testUser));
+    given(logRepository.deactivateByUserId(TEST_USER_ID)).willReturn(5);
+    given(threadRepository.deactivateByUserId(TEST_USER_ID)).willReturn(3);
+    given(commentRepository.deactivateByUserId(TEST_USER_ID)).willReturn(10);
+    given(likeRepository.deactivateByUserId(TEST_USER_ID)).willReturn(7);
 
     // when
     userService.deactivateAccount(TEST_USER_ID_STRING);
@@ -198,6 +237,10 @@ class UserServiceTest {
     assertThat(testUser.getRefreshToken()).isNull();
     assertThat(testUser.getRefreshTokenExpiry()).isNull();
     verify(userRepository).findById(TEST_USER_ID);
+    verify(logRepository).deactivateByUserId(TEST_USER_ID);
+    verify(threadRepository).deactivateByUserId(TEST_USER_ID);
+    verify(commentRepository).deactivateByUserId(TEST_USER_ID);
+    verify(likeRepository).deactivateByUserId(TEST_USER_ID);
   }
 
   @Test
@@ -249,5 +292,39 @@ class UserServiceTest {
     assertThatThrownBy(() -> userService.deactivateAccount(null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("사용자 ID는 필수입니다.");
+  }
+
+  @Test
+  @DisplayName("사용자 생성 데이터 재활성화 - 성공")
+  void reactivateUserGeneratedData_success() {
+    // given
+    given(logRepository.reactivateByUserId(TEST_USER_ID)).willReturn(5);
+    given(threadRepository.reactivateByUserId(TEST_USER_ID)).willReturn(3);
+    given(commentRepository.reactivateByUserId(TEST_USER_ID)).willReturn(10);
+    given(likeRepository.reactivateByUserId(TEST_USER_ID)).willReturn(7);
+
+    // when
+    userService.reactivateUserGeneratedData(testUser);
+
+    // then
+    verify(logRepository).reactivateByUserId(TEST_USER_ID);
+    verify(threadRepository).reactivateByUserId(TEST_USER_ID);
+    verify(commentRepository).reactivateByUserId(TEST_USER_ID);
+    verify(likeRepository).reactivateByUserId(TEST_USER_ID);
+  }
+
+  @Test
+  @DisplayName("사용자 생성 데이터 재활성화 - 재활성화 도중 오류 발생")
+  void reactivateUserGeneratedData_exceptionDuringReactivation() {
+    // given
+    given(logRepository.reactivateByUserId(TEST_USER_ID)).willThrow(
+        new RuntimeException("Database error"));
+
+    // when & then
+    assertThatThrownBy(() -> userService.reactivateUserGeneratedData(testUser))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Database error");
+
+    verify(logRepository).reactivateByUserId(TEST_USER_ID);
   }
 }


### PR DESCRIPTION
# Pull Request

## 🎯 문제 정의 및 배경

### 🔗 관련 이슈

- 데이터 프라이버시 보호 요구사항 개선

### 📌 문제 설명

Log, Thread, Comment, Like 기능이 구현되기 전이라 미루었던 계정삭제를 구현합니다.
이 과정에서 사용자의 데이터 상태를 보관하는 방식에 문제가 발생했습니다. 기존 시스템에서는 계정 탈퇴 시 모든 사용자 콘텐츠를 `isPublic = false`로 설정하고, 재활성화 시 `isPublic = true`로 일괄 변경하여 사용자가 원래 비공개로 설정했던 개인적인 게시물까지 모두 공개되는 문제가 있었습니다.

### 🎭 문제 발생 배경

- **계정 탈퇴 프로세스**: 모든 콘텐츠를 `isPublic = false`로 일괄 변경
- **계정 재활성화 프로세스**: 모든 콘텐츠를 `isPublic = true`로 일괄 변경
- **결과**: 원래 비공개였던 개인적인 게시물 등이 모두 공개됨
- **영향**: GDPR 및 개인정보보호법 위반 가능성, 사용자 신뢰도 심각한 타격

---

## 🔍 원인 분석

### 🐛 근본 원인

기존 코드에서 사용자 콘텐츠의 **원본 공개설정을 보존하지 않고** `isPublic` 필드를 직접 조작하는 방식을 사용했기 때문입니다.

```java
// 문제가 있던 기존 코드
@Query("UPDATE Log l SET l.isPublic = false WHERE l.user.id = :userId")  // 탈퇴 시
@Query("UPDATE Log l SET l.isPublic = true WHERE l.user.id = :userId")   // 재활성화 시 - 문제발생 코드
```

### 🔬 디버깅 과정

1. **사전 검증을 통한 문제 발견**: 테스트 작성 중 크리티컬 수준의 데이터 프라이버시 문제 감지
2. **LogRepository와 ThreadRepository 분석**: `reactivateByUserId` 메서드가 모든 콘텐츠를 강제로 공개하는 로직 확인
3. **사용자 시나리오 추적**: 개인 게시글(private) → 계정 탈퇴 → 계정 재활성화 → 개인 일기가 public으로 변경되는 플로우 확인

### 💭 고려했던 가능성들

- 단순한 버그로 인한 일시적 문제
- 특정 조건에서만 발생하는 엣지 케이스
- 하지만 분석 결과 **시스템 전체의 구조적 문제**임을 확인

---

## 💡 해결 방안

### 🤔 검토한 해결 방법들

#### 방법 1: Hard Delete

- **장점**: 구현 단순, GDPR 즉시 만족
- **단점**: 데이터 영구 손실, 복구 불가, 외래 키 제약조건 문제

#### 방법 2: Status Enum

- **장점**: 다양한 상태 표현 가능 (ACTIVE, DEACTIVATED, BANNED 등)
- **단점**: 상태 변경 시점 기록 어려움, 인덱스 효율 낮음

#### 방법 3: Soft Delete with deactivatedAt

- **장점**: 재활성화 용이, 탈퇴 시점 기록, 데이터 무결성 유지, 원본 설정 보존
- **단점**: 쿼리 복잡성 증가, 스토리지 사용량 증가

### ✅ 선택한 방법과 이유

**Soft Delete 패턴 (deactivatedAt 타임스탬프)**을 선택했습니다.

- **데이터 무결성 보장**: 원본 `isPublic` 설정을 절대 변경하지 않음
- **업계 표준**: Netflix, GitHub, Slack 등 대형 서비스에서 검증된 패턴
- **GDPR 준수**: 향후 익명화 프로세스 추가로 완전한 규정 준수 가능
- **성능 최적화**: 부분 인덱스 활용으로 조회 성능 향상

---

## 📊 결과 및 영향

### 🚀 개선 사항

- **프라이버시 보호**: 사용자의 원본 공개설정 100% 보존
- **GDPR 준수**: 개인정보보호법 요구사항 충족
- **데이터 무결성**: 외래 키 제약조건 유지
- **성능 향상**: 복합 인덱스로 공개 데이터 조회 최적화
- **사용자 신뢰**: 의도하지 않은 콘텐츠 공개 방지

### ⚠️ 주의 사항

- 모든 조회 쿼리에 `deactivatedAt IS NULL` 조건 추가 필요
- 비활성 데이터 조회를 위한 별도 메서드 구현 시 Native Query 사용
- 스토리지 사용량 약간 증가 (비활성 데이터 보존)

### 📈 성능 영향

- **긍정적 영향**: 복합 인덱스로 공개 데이터 조회 속도 향상
- **메모리 효율**: 비활성 데이터가 조회에서 제외되어 메모리 사용량 감소
- **인덱스 최적화**: 6개의 전략적 인덱스로 다양한 조회 패턴 지원

---

## 📝 구현 세부사항

### 📁 주요 변경 내용

1. **Domain Layer**: Log, Thread 엔티티에 `deactivatedAt` 필드 추가
2. **Repository Layer**: 모든 조회 쿼리에 soft delete 조건 적용 (34개 메서드 수정)
3. **Service Layer**: 사용자 데이터 비활성화 로직 구현 및 예외 처리 개선
4. **Exception Layer**: 중복 닉네임 처리를 위한 전용 예외 클래스 추가
5. **Test Layer**: 새로운 로직에 대한 포괄적 테스트 케이스 추가

---

## 🔧 기술적 변경 사항

### 📁 주요 변경 파일

- `src/main/java/org/nodystudio/nodybackend/domain/log/Log.java`
- `src/main/java/org/nodystudio/nodybackend/domain/thread/Thread.java`
- `src/main/java/org/nodystudio/nodybackend/repository/LogRepository.java`
- `src/main/java/org/nodystudio/nodybackend/repository/ThreadRepository.java`
- `src/main/java/org/nodystudio/nodybackend/repository/CommentRepository.java`
- `src/main/java/org/nodystudio/nodybackend/repository/LikeRepository.java`
- `src/main/java/org/nodystudio/nodybackend/service/user/UserService.java`
- `src/main/java/org/nodystudio/nodybackend/exception/custom/DuplicateNicknameException.java`
- `src/test/java/org/nodystudio/nodybackend/service/user/UserServiceTest.java`
- `src/test/java/org/nodystudio/nodybackend/repository/UserRepositoryIntegrationTest.java`

### 🛠️ API 변경 사항

API 엔드포인트 자체는 변경되지 않았으나, 내부 로직이 개선되었습니다:

- 기존 API 호환성 100% 유지
- 응답 데이터에서 비활성화된 콘텐츠 자동 제외
- 사용자 경험 개선 (의도하지 않은 콘텐츠 노출 방지)

### 🗄️ 데이터베이스 변경 사항

- [x] 기존 테이블 스키마 수정 (logs, threads 테이블에 deactivated_at 컬럼 추가)
- [x] 인덱스 추가/변경 (성능 최적화를 위한 6개 인덱스 추가)

### 🔐 보안 관련 변경

- [x] 데이터 프라이버시 보호 강화 (원본 공개설정 보존)
- [x] GDPR/개인정보보호법 준수 로직 구현

---

## ✅ 체크리스트

### 📋 코드 품질

- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 주석과 콘솔 로그를 제거했습니다
- [x] 적절한 예외 처리를 구현했습니다
- [x] API 응답 형식이 일관성 있게 구현되었습니다 (`ApiResponse<T>` 사용)

### 🧪 테스트

- [x] 새로운 기능에 대한 단위 테스트를 작성했습니다
- [x] Repository 통합 테스트 케이스를 추가했습니다

### 📖 문서화

- [x] 코드 주석이 적절히 작성되었습니다 (한국어)
- [x] 변경 사항에 대한 문서를 작성했습니다

### 🔧 설정 및 환경

- [x] 개발 환경에서 정상 동작을 확인했습니다
- [x] 프로덕션 환경 설정을 고려했습니다 (MVP 단계)
- [x] 환경별 설정 파일이 적절히 구성되었습니다 (dev, prod)
- [x] 의존성 추가 시 버전 충돌을 확인했습니다

---

## 🧪 테스트 결과

### 🔍 테스트 시나리오

1. **계정 탈퇴 후 재활성화 시 원본 공개설정 보존 확인**
2. **닉네임 중복 검증 로직 정상 동작 확인**
3. **비활성화된 콘텐츠가 일반 조회에서 제외되는지 확인**
4. **Repository 계층 soft delete 패턴 정상 작동 확인**
5. **Service 계층 예외 처리 로직 검증**

### 📊 테스트 커버리지

- [x] 단위 테스트 커버리지: 새로운 로직 100% 커버
- [x] 통합 테스트 완료 (Repository 계층)
- [x] 전체 테스트 스위트 통과 확인

---

## 📸 스크린샷 / 로그

### 테스트 실행 결과

```bash
./gradlew test
BUILD SUCCESSFUL in 15s
> 모든 테스트 통과 확인
```

### 데이터베이스 스키마 변경 확인

```sql
-- logs 테이블에 deactivated_at 컬럼 추가됨
DESCRIBE logs;
-- threads 테이블에 deactivated_at 컬럼 추가됨
DESCRIBE threads;
```

---

## 🚀 배포 시 주의사항

### MVP 단계 배포 특이사항

- **스키마 변경**: JPA `ddl-auto=update` 설정으로 자동 스키마 업데이트
- **데이터 호환성**: 기존 데이터는 `deactivated_at = NULL`로 활성 상태 유지
- **무중단 배포**: 기존 API 호환성 100% 보장으로 무중단 배포 가능

### 모니터링 포인트

1. **비활성화 데이터 비율**: 시간 경과에 따른 데이터 분포 확인
2. **쿼리 성능**: 새로운 조건절로 인한 성능 영향 모니터링
3. **사용자 피드백**: 의도하지 않은 콘텐츠 노출 관련 이슈 모니터링

### 향후 개선 사항

- **GDPR 완전 준수**: 30일 후 개인정보 익명화 배치 작업 추가 예정
- **모니터링 강화**: 데이터 프라이버시 관련 메트릭 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 로그, 스레드, 댓글, 좋아요에 대해 계정 탈퇴 시 비활성화 및 재활성화 기능이 추가되어 사용자 콘텐츠 관리가 강화되었습니다.
  * 닉네임 중복 검사 기능이 도입되어 중복 닉네임 사용 시 예외가 발생합니다.
* **버그 수정 및 개선**
  * 로그 및 스레드 조회 시 비활성화된 항목은 자동으로 제외되어 활성 상태 콘텐츠만 표시됩니다.
  * 사용자 계정 비활성화 및 재활성화 시 관련 모든 사용자 생성 데이터가 일괄 처리되어 데이터 일관성이 향상되었습니다.
* **테스트**
  * 로그 및 스레드 도메인에 대한 활성화 상태 관련 단위 테스트가 추가되어 안정성이 강화되었습니다.
  * 사용자 저장소에 대한 통합 테스트가 추가되어 닉네임 중복 검사 및 활성 사용자 필터링이 검증되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->