### PR TITLE
feat(auth): 사용자 로그아웃 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,7 @@ out/
 
 ### Application Config ###
 # Sensitive configuration files
-/src/main/resources/application-dev.yaml
-/src/main/resources/application-prod.yaml
+/src/main/resources/application-*.yaml
 
 ### Logs ###
 logs

--- a/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
+++ b/src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java
@@ -103,7 +103,8 @@ public class SecurityConfig {
                 userInfo -> userInfo.userService(customOAuth2UserService))
             .successHandler(oAuth2LoginSuccessHandler))
         .authorizeHttpRequests(authorize -> authorize
-            .requestMatchers("/api/auth/**", "/api/public/**", "/oauth2/**", "/login/**")
+            .requestMatchers("/api/auth/refresh", "/api/auth/login", "/api/auth/signup", "/api/public/**", "/oauth2/**",
+                "/login/**")
             .permitAll()
             // 공개 조회 API 허용 (비로그인 사용자도 접근 가능)
             .requestMatchers(HttpMethod.GET, "/api/threads/**").permitAll()
@@ -139,7 +140,8 @@ public class SecurityConfig {
                 userInfo -> userInfo.userService(customOAuth2UserService))
             .successHandler(oAuth2LoginSuccessHandler))
         .authorizeHttpRequests(authorize -> authorize
-            .requestMatchers("/api/auth/**", "/api/public/**", "/oauth2/**", "/login/**")
+            .requestMatchers("/api/auth/refresh", "/api/auth/login", "/api/auth/signup", "/api/public/**", "/oauth2/**",
+                "/login/**")
             .permitAll()
             .requestMatchers("/api/admin/**").hasRole("ADMIN")
             // 공개 조회 API 허용 (비로그인 사용자도 접근 가능)

--- a/src/main/java/org/nodystudio/nodybackend/controller/auth/AuthController.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/auth/AuthController.java
@@ -6,9 +6,13 @@ import org.nodystudio.nodybackend.controller.auth.docs.AuthApiDocs;
 import org.nodystudio.nodybackend.dto.ApiResponse;
 import org.nodystudio.nodybackend.dto.TokenRefreshRequestDto;
 import org.nodystudio.nodybackend.dto.TokenResponseDto;
+import org.nodystudio.nodybackend.dto.code.ErrorCode;
 import org.nodystudio.nodybackend.dto.code.SuccessCode;
+import org.nodystudio.nodybackend.exception.custom.UnauthorizedException;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.nodystudio.nodybackend.service.auth.AuthService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,5 +42,24 @@ public class AuthController implements AuthApiDocs {
     return ResponseEntity
         .status(SuccessCode.TOKEN_REFRESHED.getStatus())
         .body(ApiResponse.success(SuccessCode.TOKEN_REFRESHED, tokenData));
+  }
+
+  /**
+   * 로그아웃 현재 로그인한 사용자를 로그아웃하고 Refresh Token을 무효화합니다.
+   *
+   * @param userDetails 현재 인증된 사용자 정보
+   * @return 로그아웃 응답
+   */
+  @Override
+  @PostMapping(value = "/logout")
+  public ResponseEntity<ApiResponse<Void>> logout(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    if (userDetails == null || userDetails.getUser() == null) {
+      throw new UnauthorizedException(ErrorCode.USER_NOT_AUTHENTICATED);
+    }
+    authService.logout(userDetails.getUser());
+    return ResponseEntity
+        .status(SuccessCode.LOGOUT_SUCCESS.getStatus())
+        .body(ApiResponse.success(SuccessCode.LOGOUT_SUCCESS, null));
   }
 }

--- a/src/main/java/org/nodystudio/nodybackend/controller/auth/docs/AuthApiDocs.java
+++ b/src/main/java/org/nodystudio/nodybackend/controller/auth/docs/AuthApiDocs.java
@@ -9,7 +9,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.nodystudio.nodybackend.dto.TokenRefreshRequestDto;
 import org.nodystudio.nodybackend.dto.TokenResponseDto;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 
 /**
@@ -18,34 +20,20 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "인증", description = "JWT 토큰 기반 인증 관련 API")
 public interface AuthApiDocs {
 
-  @Operation(
-      summary = "Access Token 재발급",
-      description = "유효한 Refresh Token을 사용하여 새로운 Access Token을 발급받습니다."
-  )
+  @Operation(summary = "Access Token 재발급", description = "유효한 Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.")
   @ApiResponses({
-      @ApiResponse(
-          responseCode = "200",
-          description = "토큰 재발급 성공",
-          useReturnTypeSchema = true
-      ),
-      @ApiResponse(
-          responseCode = "401",
-          description = "유효하지 않은 Refresh Token",
-          content = @Content(
-              mediaType = "application/json",
-              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
-          )
-      ),
-      @ApiResponse(
-          responseCode = "400",
-          description = "잘못된 요청 형식",
-          content = @Content(
-              mediaType = "application/json",
-              schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)
-          )
-      )
+      @ApiResponse(responseCode = "200", description = "토큰 재발급 성공", useReturnTypeSchema = true),
+      @ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh Token", content = @Content(mediaType = "application/json", schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class))),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(mediaType = "application/json", schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)))
   })
   ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<TokenResponseDto>> refreshAccessToken(
-      @Valid @RequestBody TokenRefreshRequestDto requestDto
-  );
+      @Valid @RequestBody TokenRefreshRequestDto requestDto);
+
+  @Operation(summary = "로그아웃", description = "현재 로그인한 사용자를 로그아웃하고 Refresh Token을 무효화합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "로그아웃 성공", useReturnTypeSchema = true),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content(mediaType = "application/json", schema = @Schema(implementation = org.nodystudio.nodybackend.dto.ApiResponse.class)))
+  })
+  ResponseEntity<org.nodystudio.nodybackend.dto.ApiResponse<Void>> logout(
+      @AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/org/nodystudio/nodybackend/service/auth/AuthService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/auth/AuthService.java
@@ -143,6 +143,21 @@ public class AuthService {
   }
 
   /**
+   * 사용자를 로그아웃하고 Refresh Token을 무효화합니다.
+   *
+   * @param user 로그아웃할 사용자
+   */
+  @Transactional
+  public void logout(User user) {
+    log.debug("사용자 ID: {}의 로그아웃 요청 처리 시작", user.getId());
+
+    user.clearRefreshToken();
+    userRepository.save(user);
+
+    log.info("사용자 ID: {}의 로그아웃 완료 - Refresh Token 무효화됨", user.getId());
+  }
+
+  /**
    * 새로운 Access Token과 Refresh Token을 생성하고 사용자 정보를 업데이트합니다.
    */
   private TokenPair rotateTokens(User user) {

--- a/src/test/java/org/nodystudio/nodybackend/controller/auth/AuthControllerTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/controller/auth/AuthControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -12,11 +13,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.dto.TokenRefreshRequestDto;
 import org.nodystudio.nodybackend.dto.TokenResponseDto;
 import org.nodystudio.nodybackend.dto.code.ErrorCode;
@@ -25,21 +28,26 @@ import org.nodystudio.nodybackend.exception.GlobalExceptionHandler;
 import org.nodystudio.nodybackend.exception.custom.InvalidRefreshTokenException;
 import org.nodystudio.nodybackend.service.auth.AuthService;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("AuthController 테스트")
 class AuthControllerTest {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
   private final String refreshToken = "test-refresh-token";
   private final String newAccessToken = "new-access-token";
+
   @Mock
   private AuthService authService;
+
   @InjectMocks
   private AuthController authController;
+
   private MockMvc mockMvc;
 
   @BeforeEach
@@ -49,60 +57,117 @@ class AuthControllerTest {
         .build();
   }
 
-  @Test
-  @DisplayName("POST /api/auth/refresh - 유효한 리프레시 토큰으로 성공 시 200 OK 및 새 토큰 반환")
-  void refreshAccessToken_shouldReturnOkAndNewTokens_whenTokenIsValid() throws Exception {
-    // given
-    TokenRefreshRequestDto requestDto = new TokenRefreshRequestDto(refreshToken);
-    TokenResponseDto responseDto = TokenResponseDto.builder()
-        .grantType("Bearer")
-        .accessToken(newAccessToken)
-        .refreshToken(refreshToken)
-        .accessTokenExpiresIn(900000L)
-        .build();
+  @Nested
+  @DisplayName("토큰 갱신 테스트")
+  class TokenRefreshTests {
 
-    given(authService.refreshAccessToken(any(TokenRefreshRequestDto.class)))
-        .willReturn(responseDto);
+    @Test
+    @DisplayName("유효한 리프레시 토큰으로 토큰을 성공적으로 갱신한다")
+    void refreshAccessToken_WithValidToken_ShouldReturnOkAndNewTokens() throws Exception {
+      // given
+      TokenRefreshRequestDto requestDto = new TokenRefreshRequestDto(refreshToken);
+      TokenResponseDto responseDto = TokenResponseDto.builder()
+          .grantType("Bearer")
+          .accessToken(newAccessToken)
+          .refreshToken(refreshToken)
+          .accessTokenExpiresIn(900000L)
+          .build();
 
-    // when & then
-    mockMvc
-        .perform(post("/api/auth/refresh")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(requestDto)))
-        .andDo(print())
-        .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.status").value(SuccessCode.TOKEN_REFRESHED.getStatus().value()))
-        .andExpect(jsonPath("$.code").value(SuccessCode.TOKEN_REFRESHED.getCode()))
-        .andExpect(jsonPath("$.message").value(SuccessCode.TOKEN_REFRESHED.getMessage()))
-        .andExpect(jsonPath("$.data.grantType").value("Bearer"))
-        .andExpect(jsonPath("$.data.accessToken").value(newAccessToken))
-        .andExpect(jsonPath("$.data.refreshToken").value(refreshToken));
+      given(authService.refreshAccessToken(any(TokenRefreshRequestDto.class)))
+          .willReturn(responseDto);
 
-    // verify: authService.refreshAccessToken이 1번 호출되었는지 확인
-    then(authService).should(times(1)).refreshAccessToken(any(TokenRefreshRequestDto.class));
+      // when & then
+      mockMvc
+          .perform(post("/api/auth/refresh")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(requestDto)))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(jsonPath("$.status").value(SuccessCode.TOKEN_REFRESHED.getStatus().value()))
+          .andExpect(jsonPath("$.code").value(SuccessCode.TOKEN_REFRESHED.getCode()))
+          .andExpect(jsonPath("$.message").value(SuccessCode.TOKEN_REFRESHED.getMessage()))
+          .andExpect(jsonPath("$.data.grantType").value("Bearer"))
+          .andExpect(jsonPath("$.data.accessToken").value(newAccessToken))
+          .andExpect(jsonPath("$.data.refreshToken").value(refreshToken));
+
+      // then
+      then(authService).should(times(1)).refreshAccessToken(any(TokenRefreshRequestDto.class));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 리프레시 토큰일 때 401 Unauthorized를 반환한다")
+    void refreshAccessToken_WithInvalidToken_ShouldReturnUnauthorized() throws Exception {
+      // given
+      TokenRefreshRequestDto requestDto = new TokenRefreshRequestDto("invalid-token");
+
+      given(authService.refreshAccessToken(any(TokenRefreshRequestDto.class)))
+          .willThrow(new InvalidRefreshTokenException(ErrorCode.INVALID_REFRESH_TOKEN));
+
+      // when & then
+      mockMvc.perform(post("/api/auth/refresh")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(requestDto)))
+          .andDo(print())
+          .andExpect(status().isUnauthorized())
+          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(jsonPath("$.status").value(ErrorCode.INVALID_REFRESH_TOKEN.getStatus().value()))
+          .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REFRESH_TOKEN.getCode()))
+          .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_REFRESH_TOKEN.getMessage()));
+
+      // then
+      then(authService).should(times(1)).refreshAccessToken(any(TokenRefreshRequestDto.class));
+    }
   }
 
-  @Test
-  @DisplayName("POST /api/auth/refresh - 유효하지 않은 리프레시 토큰으로 실패 시 401 Unauthorized 반환")
-  void refreshAccessToken_shouldReturnBadRequest_whenTokenIsInvalid() throws Exception {
-    // given
-    TokenRefreshRequestDto requestDto = new TokenRefreshRequestDto("invalid-token");
+  @Nested
+  @DisplayName("로그아웃 테스트")
+  class LogoutTests {
 
-    given(authService.refreshAccessToken(any(TokenRefreshRequestDto.class)))
-        .willThrow(new InvalidRefreshTokenException(ErrorCode.INVALID_REFRESH_TOKEN));
+    // Note: 단위 테스트에서는 @AuthenticationPrincipal이 제대로 작동하지 않으므로
+    // 실제 인증된 사용자의 로그아웃 성공 케이스는
+    // FrontendAuthFlowTest.logout_shouldInvalidateRefreshTokenAndReturnSuccess()에서
+    // 검증됨
 
-    // when & then
-    mockMvc.perform(post("/api/auth/refresh")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(requestDto)))
-        .andDo(print())
-        .andExpect(status().isUnauthorized())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.status").value(ErrorCode.INVALID_REFRESH_TOKEN.getStatus().value()))
-        .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REFRESH_TOKEN.getCode()))
-        .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_REFRESH_TOKEN.getMessage()));
+    @Test
+    @DisplayName("인증되지 않은 사용자일 때 401 Unauthorized를 반환한다")
+    void logout_WithUnauthenticatedUser_ShouldReturnUnauthorized() throws Exception {
+      // when & then
+      mockMvc
+          .perform(post("/api/auth/logout")
+              .contentType(MediaType.APPLICATION_JSON))
+          .andDo(print())
+          .andExpect(status().isUnauthorized())
+          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(jsonPath("$.status").value(ErrorCode.USER_NOT_AUTHENTICATED.getStatus().value()))
+          .andExpect(jsonPath("$.code").value(ErrorCode.USER_NOT_AUTHENTICATED.getCode()))
+          .andExpect(jsonPath("$.message").value(ErrorCode.USER_NOT_AUTHENTICATED.getMessage()));
 
-    // verify: authService.refreshAccessToken이 1번 호출되었는지 확인
-    then(authService).should(times(1)).refreshAccessToken(any(TokenRefreshRequestDto.class));
+      // then
+      then(authService).should(times(0)).logout(any(User.class));
+    }
+
+    @Test
+    @DisplayName("CustomUserDetails가 null일 때 401 Unauthorized를 반환한다")
+    void logout_WithNullUserDetails_ShouldReturnUnauthorized() throws Exception {
+      // given
+      UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+          null, null, null);
+
+      // when & then
+      mockMvc
+          .perform(post("/api/auth/logout")
+              .with(authentication(authentication))
+              .contentType(MediaType.APPLICATION_JSON))
+          .andDo(print())
+          .andExpect(status().isUnauthorized())
+          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(jsonPath("$.status").value(ErrorCode.USER_NOT_AUTHENTICATED.getStatus().value()))
+          .andExpect(jsonPath("$.code").value(ErrorCode.USER_NOT_AUTHENTICATED.getCode()))
+          .andExpect(jsonPath("$.message").value(ErrorCode.USER_NOT_AUTHENTICATED.getMessage()));
+
+      // then
+      then(authService).should(times(0)).logout(any(User.class));
+    }
   }
 }

--- a/src/test/java/org/nodystudio/nodybackend/controller/auth/AuthControllerTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/controller/auth/AuthControllerTest.java
@@ -3,14 +3,13 @@ package org.nodystudio.nodybackend.controller.auth;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.BDDMockito.times;
+import static org.mockito.Mockito.times;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +27,8 @@ import org.nodystudio.nodybackend.service.auth.AuthService;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
 class AuthControllerTest {
@@ -92,8 +93,8 @@ class AuthControllerTest {
 
     // when & then
     mockMvc.perform(post("/api/auth/refresh")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(requestDto)))
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(requestDto)))
         .andDo(print())
         .andExpect(status().isUnauthorized())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/org/nodystudio/nodybackend/controller/thread/ThreadControllerUpdateTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/controller/thread/ThreadControllerUpdateTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.nodystudio.nodybackend.dto.ApiResponse;
 import org.nodystudio.nodybackend.dto.thread.ThreadResponse;
 import org.nodystudio.nodybackend.dto.thread.ThreadUpdateRequest;
-import org.nodystudio.nodybackend.dto.user.UserSummaryResponse;
 import org.nodystudio.nodybackend.fixture.ThreadTestFixture;
 import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.nodystudio.nodybackend.service.thread.ThreadService;
@@ -31,167 +31,175 @@ import org.springframework.http.ResponseEntity;
 @DisplayName("ThreadController 스레드 수정 테스트")
 class ThreadControllerUpdateTest {
 
-    @Mock
-    private ThreadService threadService;
+  @Mock
+  private ThreadService threadService;
 
-    @InjectMocks
-    private ThreadController threadController;
+  @InjectMocks
+  private ThreadController threadController;
 
-    @Nested
-    @DisplayName("PUT /api/threads/{id} - 스레드 수정")
-    class UpdateThreadTests {
+  @Nested
+  @DisplayName("PUT /api/threads/{id} - 스레드 수정")
+  class UpdateThreadTests {
 
-        @Test
-        @DisplayName("유효한 요청으로 스레드 수정 시 성공한다")
-        void updateThread_WithValidRequest_ShouldReturnUpdatedThread() {
-            // given
-            Long threadId = ThreadTestFixture.DEFAULT_THREAD_ID;
-            ThreadUpdateRequest request = ThreadTestFixture.createDefaultThreadUpdateRequest();
+    @Test
+    @DisplayName("유효한 요청으로 스레드 수정 시 성공한다")
+    void updateThread_WithValidRequest_ShouldReturnUpdatedThread() {
+      // given
+      Long threadId = ThreadTestFixture.DEFAULT_THREAD_ID;
+      ThreadUpdateRequest request = ThreadTestFixture.createDefaultThreadUpdateRequest();
 
-            ThreadResponse updatedResponse = ThreadResponse.builder()
-                .id(threadId)
-                .content("수정된 스레드 내용")
-                .isPublic(false)
-                .viewCount(0L)
-                .user(ThreadTestFixture.createDefaultUserSummaryResponse())
-                .log(null)
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .isLinkedToLog(false)
-                .isIndependent(true)
-                .build();
+      ThreadResponse updatedResponse = ThreadResponse.builder()
+          .id(threadId)
+          .content("수정된 스레드 내용")
+          .isPublic(false)
+          .viewCount(0L)
+          .user(ThreadTestFixture.createDefaultUserSummaryResponse())
+          .log(null)
+          .createdAt(LocalDateTime.now())
+          .updatedAt(LocalDateTime.now())
+          .isLinkedToLog(false)
+          .isIndependent(true)
+          .build();
 
-            given(threadService.updateThread(eq(threadId), any(ThreadUpdateRequest.class), eq(ThreadTestFixture.DEFAULT_USER_EMAIL)))
-                .willReturn(updatedResponse);
+      given(threadService.updateThread(eq(threadId), any(ThreadUpdateRequest.class),
+          eq(ThreadTestFixture.DEFAULT_USER_EMAIL)))
+          .willReturn(updatedResponse);
 
-            // when
-            CustomUserDetails userDetails = ThreadTestFixture.createMockUserDetails();
-            ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.updateThread(
-                threadId, userDetails, request);
+      // when
+      CustomUserDetails userDetails = ThreadTestFixture.createMockUserDetails();
+      ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.updateThread(
+          threadId, userDetails, request);
 
-            // then
-            assertThat(response.getStatusCode().value()).isEqualTo(200);
-            assertThat(response.getBody()).isNotNull();
-            ApiResponse<ThreadResponse> body = Objects.requireNonNull(response.getBody());
-            assertThat(body.getStatus()).isEqualTo(200);
-            assertThat(body.getData().getId()).isEqualTo(threadId);
-            assertThat(body.getData().getContent()).isEqualTo("수정된 스레드 내용");
-            assertThat(body.getData().getIsPublic()).isFalse();
-            assertThat(body.getMessage()).isEqualTo("스레드가 성공적으로 수정되었습니다.");
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(200);
+      assertThat(response.getBody()).isNotNull();
+      ApiResponse<ThreadResponse> body = Objects.requireNonNull(response.getBody());
+      assertThat(body.getStatus()).isEqualTo(200);
+      assertThat(body.getData().getId()).isEqualTo(threadId);
+      assertThat(body.getData().getContent()).isEqualTo("수정된 스레드 내용");
+      assertThat(body.getData().getIsPublic()).isFalse();
+      assertThat(body.getMessage()).isEqualTo("스레드가 성공적으로 수정되었습니다.");
 
-            verify(threadService).updateThread(eq(threadId), any(ThreadUpdateRequest.class), eq(ThreadTestFixture.DEFAULT_USER_EMAIL));
-        }
-
-        @Test
-        @DisplayName("내용만 수정하는 경우 성공한다")
-        void updateThread_ContentOnly_ShouldUpdateContent() {
-            // given
-            Long threadId = ThreadTestFixture.DEFAULT_THREAD_ID;
-            ThreadUpdateRequest request = ThreadTestFixture.createContentOnlyUpdateRequest("내용만 수정");
-
-            ThreadResponse updatedResponse = ThreadResponse.builder()
-                .id(threadId)
-                .content("내용만 수정")
-                .isPublic(true)
-                .viewCount(0L)
-                .user(ThreadTestFixture.createDefaultUserSummaryResponse())
-                .log(null)
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .isLinkedToLog(false)
-                .isIndependent(true)
-                .build();
-
-            given(threadService.updateThread(eq(threadId), any(ThreadUpdateRequest.class), eq(ThreadTestFixture.DEFAULT_USER_EMAIL)))
-                .willReturn(updatedResponse);
-
-            // when
-            CustomUserDetails userDetails = ThreadTestFixture.createMockUserDetails();
-            ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.updateThread(
-                threadId, userDetails, request);
-
-            // then
-            assertThat(response.getStatusCode().value()).isEqualTo(200);
-            assertThat(response.getBody()).isNotNull();
-            ApiResponse<ThreadResponse> body = Objects.requireNonNull(response.getBody());
-            assertThat(body.getData().getContent()).isEqualTo("내용만 수정");
-
-            verify(threadService).updateThread(eq(threadId), any(ThreadUpdateRequest.class), eq(ThreadTestFixture.DEFAULT_USER_EMAIL));
-        }
-
-        @Test
-        @DisplayName("공개 설정만 수정하는 경우 성공한다")
-        void updateThread_PublicSettingOnly_ShouldUpdatePublicSetting() {
-            // given
-            Long threadId = ThreadTestFixture.DEFAULT_THREAD_ID;
-            ThreadUpdateRequest request = ThreadTestFixture.createPublicOnlyUpdateRequest(false);
-
-            ThreadResponse updatedResponse = ThreadResponse.builder()
-                .id(threadId)
-                .content(ThreadTestFixture.DEFAULT_THREAD_CONTENT)
-                .isPublic(false)
-                .viewCount(0L)
-                .user(ThreadTestFixture.createDefaultUserSummaryResponse())
-                .log(null)
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .isLinkedToLog(false)
-                .isIndependent(true)
-                .build();
-
-            given(threadService.updateThread(eq(threadId), any(ThreadUpdateRequest.class), eq(ThreadTestFixture.DEFAULT_USER_EMAIL)))
-                .willReturn(updatedResponse);
-
-            // when
-            CustomUserDetails userDetails = ThreadTestFixture.createMockUserDetails();
-            ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.updateThread(
-                threadId, userDetails, request);
-
-            // then
-            assertThat(response.getStatusCode().value()).isEqualTo(200);
-            assertThat(response.getBody()).isNotNull();
-            ApiResponse<ThreadResponse> body = Objects.requireNonNull(response.getBody());
-            assertThat(body.getData().getIsPublic()).isFalse();
-
-            verify(threadService).updateThread(eq(threadId), any(ThreadUpdateRequest.class), eq(ThreadTestFixture.DEFAULT_USER_EMAIL));
-        }
-
-        @Test
-        @DisplayName("로그 연결을 해제하는 경우 성공한다")
-        void updateThread_DisconnectLog_ShouldDisconnectFromLog() {
-            // given
-            Long threadId = ThreadTestFixture.DEFAULT_THREAD_ID;
-            ThreadUpdateRequest request = ThreadTestFixture.createDisconnectLogRequest();
-
-            ThreadResponse updatedResponse = ThreadResponse.builder()
-                .id(threadId)
-                .content(ThreadTestFixture.DEFAULT_THREAD_CONTENT)
-                .isPublic(true)
-                .viewCount(0L)
-                .user(ThreadTestFixture.createDefaultUserSummaryResponse())
-                .log(null)
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .isLinkedToLog(false)
-                .isIndependent(true)
-                .build();
-
-            given(threadService.updateThread(eq(threadId), any(ThreadUpdateRequest.class), eq(ThreadTestFixture.DEFAULT_USER_EMAIL)))
-                .willReturn(updatedResponse);
-
-            // when
-            CustomUserDetails userDetails = ThreadTestFixture.createMockUserDetails();
-            ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.updateThread(
-                threadId, userDetails, request);
-
-            // then
-            assertThat(response.getStatusCode().value()).isEqualTo(200);
-            assertThat(response.getBody()).isNotNull();
-            ApiResponse<ThreadResponse> body = Objects.requireNonNull(response.getBody());
-            assertThat(body.getData().getIsLinkedToLog()).isFalse();
-            assertThat(body.getData().getIsIndependent()).isTrue();
-
-            verify(threadService).updateThread(eq(threadId), any(ThreadUpdateRequest.class), eq(ThreadTestFixture.DEFAULT_USER_EMAIL));
-        }
+      verify(threadService).updateThread(eq(threadId), any(ThreadUpdateRequest.class),
+          eq(ThreadTestFixture.DEFAULT_USER_EMAIL));
     }
+
+    @Test
+    @DisplayName("내용만 수정하는 경우 성공한다")
+    void updateThread_ContentOnly_ShouldUpdateContent() {
+      // given
+      Long threadId = ThreadTestFixture.DEFAULT_THREAD_ID;
+      ThreadUpdateRequest request = ThreadTestFixture.createContentOnlyUpdateRequest("내용만 수정");
+
+      ThreadResponse updatedResponse = ThreadResponse.builder()
+          .id(threadId)
+          .content("내용만 수정")
+          .isPublic(true)
+          .viewCount(0L)
+          .user(ThreadTestFixture.createDefaultUserSummaryResponse())
+          .log(null)
+          .createdAt(LocalDateTime.now())
+          .updatedAt(LocalDateTime.now())
+          .isLinkedToLog(false)
+          .isIndependent(true)
+          .build();
+
+      given(threadService.updateThread(eq(threadId), any(ThreadUpdateRequest.class),
+          eq(ThreadTestFixture.DEFAULT_USER_EMAIL)))
+          .willReturn(updatedResponse);
+
+      // when
+      CustomUserDetails userDetails = ThreadTestFixture.createMockUserDetails();
+      ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.updateThread(
+          threadId, userDetails, request);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(200);
+      assertThat(response.getBody()).isNotNull();
+      ApiResponse<ThreadResponse> body = Objects.requireNonNull(response.getBody());
+      assertThat(body.getData().getContent()).isEqualTo("내용만 수정");
+
+      verify(threadService).updateThread(eq(threadId), any(ThreadUpdateRequest.class),
+          eq(ThreadTestFixture.DEFAULT_USER_EMAIL));
+    }
+
+    @Test
+    @DisplayName("공개 설정만 수정하는 경우 성공한다")
+    void updateThread_PublicSettingOnly_ShouldUpdatePublicSetting() {
+      // given
+      Long threadId = ThreadTestFixture.DEFAULT_THREAD_ID;
+      ThreadUpdateRequest request = ThreadTestFixture.createPublicOnlyUpdateRequest(false);
+
+      ThreadResponse updatedResponse = ThreadResponse.builder()
+          .id(threadId)
+          .content(ThreadTestFixture.DEFAULT_THREAD_CONTENT)
+          .isPublic(false)
+          .viewCount(0L)
+          .user(ThreadTestFixture.createDefaultUserSummaryResponse())
+          .log(null)
+          .createdAt(LocalDateTime.now())
+          .updatedAt(LocalDateTime.now())
+          .isLinkedToLog(false)
+          .isIndependent(true)
+          .build();
+
+      given(threadService.updateThread(eq(threadId), any(ThreadUpdateRequest.class),
+          eq(ThreadTestFixture.DEFAULT_USER_EMAIL)))
+          .willReturn(updatedResponse);
+
+      // when
+      CustomUserDetails userDetails = ThreadTestFixture.createMockUserDetails();
+      ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.updateThread(
+          threadId, userDetails, request);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(200);
+      assertThat(response.getBody()).isNotNull();
+      ApiResponse<ThreadResponse> body = Objects.requireNonNull(response.getBody());
+      assertThat(body.getData().getIsPublic()).isFalse();
+
+      verify(threadService).updateThread(eq(threadId), any(ThreadUpdateRequest.class),
+          eq(ThreadTestFixture.DEFAULT_USER_EMAIL));
+    }
+
+    @Test
+    @DisplayName("로그 연결을 해제하는 경우 성공한다")
+    void updateThread_DisconnectLog_ShouldDisconnectFromLog() {
+      // given
+      Long threadId = ThreadTestFixture.DEFAULT_THREAD_ID;
+      ThreadUpdateRequest request = ThreadTestFixture.createDisconnectLogRequest();
+
+      ThreadResponse updatedResponse = ThreadResponse.builder()
+          .id(threadId)
+          .content(ThreadTestFixture.DEFAULT_THREAD_CONTENT)
+          .isPublic(true)
+          .viewCount(0L)
+          .user(ThreadTestFixture.createDefaultUserSummaryResponse())
+          .log(null)
+          .createdAt(LocalDateTime.now())
+          .updatedAt(LocalDateTime.now())
+          .isLinkedToLog(false)
+          .isIndependent(true)
+          .build();
+
+      given(threadService.updateThread(eq(threadId), any(ThreadUpdateRequest.class),
+          eq(ThreadTestFixture.DEFAULT_USER_EMAIL)))
+          .willReturn(updatedResponse);
+
+      // when
+      CustomUserDetails userDetails = ThreadTestFixture.createMockUserDetails();
+      ResponseEntity<ApiResponse<ThreadResponse>> response = threadController.updateThread(
+          threadId, userDetails, request);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(200);
+      assertThat(response.getBody()).isNotNull();
+      ApiResponse<ThreadResponse> body = Objects.requireNonNull(response.getBody());
+      assertThat(body.getData().getIsLinkedToLog()).isFalse();
+      assertThat(body.getData().getIsIndependent()).isTrue();
+
+      verify(threadService).updateThread(eq(threadId), any(ThreadUpdateRequest.class),
+          eq(ThreadTestFixture.DEFAULT_USER_EMAIL));
+    }
+  }
 }

--- a/src/test/java/org/nodystudio/nodybackend/integration/FrontendAuthFlowTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/integration/FrontendAuthFlowTest.java
@@ -1,6 +1,7 @@
 package org.nodystudio.nodybackend.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -21,7 +22,9 @@ import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.dto.TokenRefreshRequestDto;
 import org.nodystudio.nodybackend.repository.UserRepository;
 import org.nodystudio.nodybackend.security.jwt.TokenProvider;
+import org.nodystudio.nodybackend.security.userdetails.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -70,7 +73,8 @@ class FrontendAuthFlowTest extends BaseIntegrationTest {
   /**
    * 시나리오 1: 프론트엔드에서 "구글로 로그인" 버튼 클릭
    * <p>
-   * 프론트엔드에서는 사용자를 '/oauth2/authorization/google'로 리다이렉트시켜야 합니다. 이는 OAuth2 인증 과정을 시작하는 표준적인 방법입니다.
+   * 프론트엔드에서는 사용자를 '/oauth2/authorization/google'로 리다이렉트시켜야 합니다. 이는 OAuth2 인증 과정을
+   * 시작하는 표준적인 방법입니다.
    */
   @Test
   @DisplayName("1. 구글 로그인 시작 - OAuth2 인증 서버로 리다이렉트")
@@ -110,8 +114,8 @@ class FrontendAuthFlowTest extends BaseIntegrationTest {
 
     // when: 프론트엔드에서 토큰 갱신 요청
     MvcResult result = mockMvc.perform(post("/api/auth/refresh")
-            .contentType("application/json")
-            .content(objectMapper.writeValueAsString(request)))
+        .contentType("application/json")
+        .content(objectMapper.writeValueAsString(request)))
         .andDo(print())
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value(200))
@@ -139,7 +143,8 @@ class FrontendAuthFlowTest extends BaseIntegrationTest {
   /**
    * 시나리오 3: 잘못된 토큰 처리
    * <p>
-   * 프론트엔드에서 잘못된 refresh token을 보냈을 때의 에러 처리입니다. 이런 경우 사용자를 다시 로그인 페이지로 리다이렉트해야 합니다.
+   * 프론트엔드에서 잘못된 refresh token을 보냈을 때의 에러 처리입니다. 이런 경우 사용자를 다시 로그인 페이지로 리다이렉트해야
+   * 합니다.
    */
   @Test
   @DisplayName("3. 잘못된 토큰 - 적절한 에러 응답으로 재로그인 유도")
@@ -149,8 +154,8 @@ class FrontendAuthFlowTest extends BaseIntegrationTest {
 
     // when: 잘못된 토큰으로 갱신 시도
     MvcResult result = mockMvc.perform(post("/api/auth/refresh")
-            .contentType("application/json")
-            .content(objectMapper.writeValueAsString(request)))
+        .contentType("application/json")
+        .content(objectMapper.writeValueAsString(request)))
         .andDo(print())
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.status").value(401))
@@ -188,14 +193,14 @@ class FrontendAuthFlowTest extends BaseIntegrationTest {
 
     // when: 첫 번째 갱신 성공
     mockMvc.perform(post("/api/auth/refresh")
-            .contentType("application/json")
-            .content(objectMapper.writeValueAsString(request)))
+        .contentType("application/json")
+        .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isOk());
 
     // then: 같은 토큰으로 두 번째 시도 시 차단
     mockMvc.perform(post("/api/auth/refresh")
-            .contentType("application/json")
-            .content(objectMapper.writeValueAsString(request)))
+        .contentType("application/json")
+        .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.code").value("A005"));
   }
@@ -221,8 +226,8 @@ class FrontendAuthFlowTest extends BaseIntegrationTest {
       TokenRefreshRequestDto request = new TokenRefreshRequestDto(currentRefreshToken);
 
       MvcResult result = mockMvc.perform(post("/api/auth/refresh")
-              .contentType("application/json")
-              .content(objectMapper.writeValueAsString(request)))
+          .contentType("application/json")
+          .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isOk())
           .andReturn();
 
@@ -237,5 +242,63 @@ class FrontendAuthFlowTest extends BaseIntegrationTest {
 
       currentRefreshToken = newRefreshToken;
     }
+  }
+
+  /**
+   * 시나리오 5: 로그아웃
+   * <p>
+   * 프론트엔드에서 사용자가 로그아웃할 때 서버에서 refresh token을 무효화하는 과정입니다.
+   */
+  @Test
+  @DisplayName("5. 로그아웃 - Refresh Token 무효화 및 성공 응답")
+  void logout_shouldInvalidateRefreshTokenAndReturnSuccess() throws Exception {
+    // given: 로그인된 사용자와 유효한 refresh token
+    User savedUser = userRepository.saveAndFlush(testUser);
+    String refreshToken = tokenProvider.createRefreshToken(savedUser);
+    LocalDateTime expiry = tokenProvider.getRefreshTokenExpiry();
+
+    savedUser.updateRefreshToken(refreshToken, expiry);
+    userRepository.saveAndFlush(savedUser);
+
+    // 인증 정보 생성
+    CustomUserDetails userDetails = new CustomUserDetails(savedUser);
+    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+        userDetails, null, userDetails.getAuthorities());
+
+    // when: 프론트엔드에서 로그아웃 요청
+    mockMvc.perform(post("/api/auth/logout")
+        .with(authentication(authentication))
+        .contentType("application/json"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value(200))
+        .andExpect(jsonPath("$.code").value("AUTH_S002"))
+        .andExpect(jsonPath("$.message").value("로그아웃에 성공했습니다."))
+        .andExpect(jsonPath("$.data").doesNotExist());
+
+    // then: 사용자의 refresh token이 무효화되었는지 확인
+    User updatedUser = userRepository.findById(savedUser.getId()).orElseThrow();
+    assertThat(updatedUser.getRefreshToken()).isNull();
+    assertThat(updatedUser.getRefreshTokenExpiry()).isNull();
+
+    // 무효화된 토큰으로 갱신 시도 시 실패하는지 확인
+    TokenRefreshRequestDto request = new TokenRefreshRequestDto(refreshToken);
+    mockMvc.perform(post("/api/auth/refresh")
+        .contentType("application/json")
+        .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("A005"));
+  }
+
+  @Test
+  @DisplayName("6. 인증되지 않은 사용자 로그아웃 시도 - 401 Unauthorized")
+  void logout_shouldReturnUnauthorized_whenNotAuthenticated() throws Exception {
+    // when: 인증되지 않은 상태에서 로그아웃 시도
+    mockMvc.perform(post("/api/auth/logout")
+        .contentType("application/json"))
+        .andDo(print())
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("A007"));
   }
 }

--- a/src/test/java/org/nodystudio/nodybackend/service/auth/AuthServiceTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/service/auth/AuthServiceTest.java
@@ -92,10 +92,9 @@ class AuthServiceTest {
 
       // verify
       then(userRepository).should(times(1))
-          .save(argThat(savedUser ->
-              savedUser.getId().equals(testUser.getId()) &&
-                  savedUser.getRefreshToken().equals(newRefreshToken) &&
-                  savedUser.getRefreshTokenExpiry().equals(validExpiry)));
+          .save(argThat(savedUser -> savedUser.getId().equals(testUser.getId()) &&
+              savedUser.getRefreshToken().equals(newRefreshToken) &&
+              savedUser.getRefreshTokenExpiry().equals(validExpiry)));
     }
 
     @Test
@@ -169,11 +168,9 @@ class AuthServiceTest {
 
       // verify
       then(userRepository).should(times(1))
-          .save(argThat(user ->
-              user.getId().equals(testUser.getId()) &&
-                  user.getRefreshToken() == null &&
-                  user.getRefreshTokenExpiry() == null
-          ));
+          .save(argThat(user -> user.getId().equals(testUser.getId()) &&
+              user.getRefreshToken() == null &&
+              user.getRefreshTokenExpiry() == null));
     }
 
     @Test
@@ -194,10 +191,53 @@ class AuthServiceTest {
 
       // verify: DB 토큰이 null로 업데이트되었는지 확인
       then(userRepository).should(times(1))
-          .save(argThat(savedUser ->
-              savedUser.getId().equals(testUser.getId()) &&
-                  savedUser.getRefreshToken() == null &&
-                  savedUser.getRefreshTokenExpiry() == null));
+          .save(argThat(savedUser -> savedUser.getId().equals(testUser.getId()) &&
+              savedUser.getRefreshToken() == null &&
+              savedUser.getRefreshTokenExpiry() == null));
+    }
+  }
+
+  @Nested
+  @DisplayName("로그아웃 테스트")
+  class LogoutTest {
+
+    @Test
+    @DisplayName("로그아웃 성공 - 사용자의 Refresh Token을 무효화한다")
+    void logout_shouldClearRefreshToken_whenUserIsValid() {
+      // given
+      testUser.updateRefreshToken(validRefreshToken, validExpiry);
+
+      // when
+      authService.logout(testUser);
+
+      // then
+      assertThat(testUser.getRefreshToken()).isNull();
+      assertThat(testUser.getRefreshTokenExpiry()).isNull();
+
+      // verify: 사용자 정보가 저장되었는지 확인
+      then(userRepository).should(times(1))
+          .save(argThat(savedUser -> savedUser.getId().equals(testUser.getId()) &&
+              savedUser.getRefreshToken() == null &&
+              savedUser.getRefreshTokenExpiry() == null));
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공 - 이미 토큰이 없는 사용자도 정상 처리된다")
+    void logout_shouldHandleGracefully_whenUserHasNoToken() {
+      // given - testUser는 이미 토큰이 없는 상태
+
+      // when
+      authService.logout(testUser);
+
+      // then
+      assertThat(testUser.getRefreshToken()).isNull();
+      assertThat(testUser.getRefreshTokenExpiry()).isNull();
+
+      // verify: 사용자 정보가 저장되었는지 확인
+      then(userRepository).should(times(1))
+          .save(argThat(savedUser -> savedUser.getId().equals(testUser.getId()) &&
+              savedUser.getRefreshToken() == null &&
+              savedUser.getRefreshTokenExpiry() == null));
     }
   }
 }


### PR DESCRIPTION
# Pull Request

## 🎯 문제 정의 및 배경

### 📌 문제 설명

현재 Nody 백엔드에는 OAuth2/JWT 기반 로그아웃 기능이 구현되어 있지 않아 구현합니다.
Refresh Token이 무효화하도록 구현했습니다.

---

## 🔍 원인 분석

### 🔬 디버깅 과정

1. 기존 인증 시스템 분석 (OAuth2 + JWT 구조)
2. Refresh Token 저장 및 관리 방식 검토
3. Spring Security 설정에서 로그아웃 처리 방법 조사

### 💭 고려했던 가능성들

- JWT Blacklist 방식 (복잡성으로 인해 배제)
- Refresh Token 기반 무효화 방식 (채택)
- 세션 기반 로그아웃 (JWT 특성상 부적합)

---

## 💡 해결 방안

### 🤔 검토한 해결 방법들

#### 방법 1: JWT Blacklist 구현

- **장점**: 완전한 토큰 무효화 가능
- **단점**: Redis 등 추가 저장소 필요, 복잡성 증가

#### 방법 2: Refresh Token 무효화

- **장점**: 간단한 구현, 기존 구조 활용
- **단점**: Access Token은 만료시까지 유효

### ✅ 선택한 방법과 이유

**Refresh Token 무효화 방식**을 선택했습니다. 
- Access Token의 짧은 만료 시간(15분)으로 보안 위험을 최소화
- 기존 데이터베이스 구조를 그대로 활용 가능
- 구현 복잡도가 낮음

---

## 📊 결과 및 영향

### 🚀 개선 사항

- 사용자가 안전하게 로그아웃할 수 있는 API 제공
- Refresh Token 무효화로 보안 강화
- 프론트엔드에서 완전한 로그아웃 플로우 구현 가능

### ⚠️ 주의 사항

- Access Token은 만료시까지 여전히 유효함 (15분)
- 로그아웃 후에도 짧은 시간 동안 기존 Access Token 사용 가능

### 📈 성능 영향

- 로그아웃 시 단순 데이터베이스 업데이트 한 번만 수행하므로 성능 영향 미미

---

## 📝 구현 세부사항

### 📁 주요 변경 내용

1. **로그아웃 API 엔드포인트 추가** (`POST /api/auth/logout`)
2. **Refresh Token 무효화 로직 구현**
3. **로그아웃 관련 API 문서화**
4. **보안 설정 업데이트** (인증 경로 매처 수정)
5. **포괄적인 테스트 케이스 추가**

---

## 🔧 기술적 변경 사항

### 📁 주요 변경 파일

- `src/main/java/org/nodystudio/nodybackend/controller/auth/AuthController.java`
- `src/main/java/org/nodystudio/nodybackend/controller/auth/docs/AuthApiDocs.java`
- `src/main/java/org/nodystudio/nodybackend/service/auth/AuthService.java`
- `src/main/java/org/nodystudio/nodybackend/config/SecurityConfig.java`
- `src/test/java/org/nodystudio/nodybackend/controller/auth/AuthControllerTest.java`
- `src/test/java/org/nodystudio/nodybackend/service/auth/AuthServiceTest.java`
- `src/test/java/org/nodystudio/nodybackend/integration/FrontendAuthFlowTest.java`
- `.gitignore` (애플리케이션 설정 패턴 수정)

### 🛠️ API 변경 사항

#### 추가된 엔드포인트

```http
POST /api/auth/logout
```

**요청**: 인증된 사용자 (JWT 토큰 필요)
**응답**: 
```json
{
  "isSuccess": true,
  "code": "AUTH_S002",
  "message": "로그아웃에 성공했습니다.",
  "data": null
}
```

### 🗄️ 데이터베이스 변경 사항

- [x] 데이터베이스 변경 없음 (기존 User 테이블의 refreshToken 필드 활용)

### 🔐 보안 관련 변경

- [x] 인증/인가 로직 변경 (로그아웃 엔드포인트 추가)
- [x] JWT 토큰 처리 수정 (Refresh Token 무효화)

---

## ✅ 체크리스트

### 📋 코드 품질

- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 주석과 콘솔 로그를 제거했습니다
- [x] 적절한 예외 처리를 구현했습니다
- [x] API 응답 형식이 일관성 있게 구현되었습니다 (`ApiResponse<T>` 사용)

### 🧪 테스트

- [x] 새로운 기능에 대한 단위 테스트를 작성했습니다
- [x] API 테스트 케이스를 추가했습니다

### 📖 문서화

- [x] API 문서가 업데이트되었습니다 (Swagger/OpenAPI)
- [x] 코드 주석이 적절히 작성되었습니다
- [x] 변경 사항에 대한 문서를 작성했습니다

### 🔧 설정 및 환경

- [x] 개발 환경에서 정상 동작을 확인했습니다
- [x] 프로덕션 환경 설정을 고려했습니다
- [x] 환경별 설정 파일이 적절히 구성되었습니다 (dev, prod)
- [x] 의존성 추가 시 버전 충돌을 확인했습니다

---

## 🧪 테스트 결과

### 🔍 테스트 시나리오

1. **정상 로그아웃 시나리오**: 인증된 사용자가 로그아웃 요청 시 성공 응답 및 Refresh Token 무효화
2. **미인증 사용자 로그아웃**: 토큰 없이 로그아웃 요청 시 401 Unauthorized 응답
3. **이미 무효화된 토큰**: 로그아웃 후 동일 Refresh Token으로 재로그인 시도 시 실패
4. **통합 테스트**: 로그인 → 로그아웃 → 토큰 갱신 시도 전체 플로우 테스트

### 📊 테스트 커버리지

- [x] 단위 테스트 커버리지: 로그아웃 관련 모든 메서드 커버
- [x] 통합 테스트 완료

---

## 📸 스크린샷 / 로그

### API 테스트 결과

**성공적인 로그아웃**:
```json
POST /api/auth/logout
Status: 200 OK
{
  "isSuccess": true,
  "code": "AUTH_S002",
  "message": "로그아웃에 성공했습니다.",
  "data": null
}
```

**미인증 로그아웃 시도**:
```json
POST /api/auth/logout
Status: 401 Unauthorized
```

---

## 🚀 배포 시 주의사항

- 기존 로그인된 사용자들의 Refresh Token은 그대로 유지됩니다.
- 프론트엔드에서 로그아웃 후 토큰 저장소 정리 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 로그아웃 엔드포인트가 추가되어 사용자가 로그아웃 요청 시 리프레시 토큰이 무효화되고 성공 메시지를 반환합니다.

* **버그 수정**
  * 인증 관련 엔드포인트의 접근 허용 범위가 축소되어, 특정 경로만 비인증 접근이 허용됩니다.

* **문서화**
  * 로그아웃 API에 대한 문서가 추가되었습니다.

* **테스트**
  * 로그아웃 기능에 대한 단위 테스트와 통합 테스트가 추가되었습니다.
  * 토큰 갱신 관련 테스트가 재구성되고, 부적절한 토큰 및 인증되지 않은 사용자에 대한 테스트가 강화되었습니다.
  * 기존 테스트 코드의 일부 포맷 및 불필요한 import가 정리되었습니다.

* **스타일**
  * 일부 테스트 코드에서 들여쓰기 및 코드 정렬이 개선되었습니다.

* **Chores**
  * .gitignore 규칙이 개선되어, 환경별 설정 파일 관리가 더욱 간편해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->