### PR TITLE
fix(auth): OAuth2 탈퇴 사용자 재로그인 시 사용자 생성 데이터 재활성화 기능 개선

### DIFF
--- a/src/main/java/org/nodystudio/nodybackend/repository/LogLikeRepository.java
+++ b/src/main/java/org/nodystudio/nodybackend/repository/LogLikeRepository.java
@@ -1,7 +1,7 @@
 package org.nodystudio.nodybackend.repository;
 
-import jakarta.persistence.LockModeType;
 import java.util.Optional;
+
 import org.nodystudio.nodybackend.domain.like.LogLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
 
 /**
  * 로그 좋아요 데이터 접근을 위한 Repository

--- a/src/main/java/org/nodystudio/nodybackend/repository/LogRepository.java
+++ b/src/main/java/org/nodystudio/nodybackend/repository/LogRepository.java
@@ -189,6 +189,14 @@ public interface LogRepository extends JpaRepository<Log, Long> {
   List<Log> findDeactivatedLogsByUserId(@Param("userId") Long userId);
 
   /**
+   * 사용자별 로그를 재활성화합니다 (계정 복구 시).
+   * Soft delete 상태를 해제하여 로그를 다시 공개합니다.
+   */
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("UPDATE Log l SET l.deactivatedAt = NULL WHERE l.user.id = :userId AND l.deactivatedAt IS NOT NULL")
+  int reactivateByUserId(@Param("userId") Long userId);
+
+  /**
    * 비활성화된 사용자 로그를 완전히 삭제합니다 (물리적 삭제).
    * 탈퇴 후 30일이 지난 사용자의 로그를 데이터베이스에서 완전히 제거합니다.
    *

--- a/src/main/java/org/nodystudio/nodybackend/repository/ThreadLikeRepository.java
+++ b/src/main/java/org/nodystudio/nodybackend/repository/ThreadLikeRepository.java
@@ -1,7 +1,7 @@
 package org.nodystudio.nodybackend.repository;
 
-import jakarta.persistence.LockModeType;
 import java.util.Optional;
+
 import org.nodystudio.nodybackend.domain.like.ThreadLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
 
 /**
  * 스레드 좋아요 데이터 접근을 위한 Repository

--- a/src/main/java/org/nodystudio/nodybackend/repository/ThreadRepository.java
+++ b/src/main/java/org/nodystudio/nodybackend/repository/ThreadRepository.java
@@ -201,6 +201,14 @@ public interface ThreadRepository extends JpaRepository<Thread, Long> {
   List<Thread> findDeactivatedThreadsByUserId(@Param("userId") Long userId);
 
   /**
+   * 사용자별 스레드를 재활성화합니다 (계정 복구 시).
+   * Soft delete 상태를 해제하여 스레드를 다시 공개합니다.
+   */
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("UPDATE Thread t SET t.deactivatedAt = NULL WHERE t.user.id = :userId AND t.deactivatedAt IS NOT NULL")
+  int reactivateByUserId(@Param("userId") Long userId);
+
+  /**
    * 비활성화된 사용자 스레드를 완전히 삭제합니다 (물리적 삭제).
    * 탈퇴 후 30일이 지난 사용자의 스레드를 데이터베이스에서 완전히 제거합니다.
    * CASCADE 설정에 의해 관련된 댓글, 좋아요 등도 함께 삭제됩니다.

--- a/src/main/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserService.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.dto.OAuthAttributes;
 import org.nodystudio.nodybackend.repository.UserRepository;
+import org.nodystudio.nodybackend.service.user.UserService;
 import org.nodystudio.nodybackend.util.LoggingUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -25,16 +26,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
   private final UserRepository userRepository;
+  private final UserService userService;
   private final OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate;
 
   @Autowired
-  public CustomOAuth2UserService(UserRepository userRepository) {
-    this(userRepository, new DefaultOAuth2UserService());
+  public CustomOAuth2UserService(UserRepository userRepository, UserService userService) {
+    this(userRepository, userService, new DefaultOAuth2UserService());
   }
 
-  public CustomOAuth2UserService(UserRepository userRepository,
+  public CustomOAuth2UserService(UserRepository userRepository, UserService userService,
       OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate) {
     this.userRepository = userRepository;
+    this.userService = userService;
     this.delegate = delegate;
   }
 
@@ -113,15 +116,12 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
           LoggingUtils.maskEmail(attributes.getEmail()),
           LoggingUtils.maskNickname(attributes.getName()));
     } else {
-      // 2. 새 사용자 등록 전 재가입 제한 검증
-      validateReRegistration(attributes.getEmail());
-
-      // 3. 탈퇴한 사용자가 있는지 확인 (소셜 ID 기준)
+      // 2. 탈퇴한 사용자가 있는지 먼저 확인 (소셜 ID 기준)
       Optional<User> deactivatedUserOptional = userRepository.findByProviderAndSocialId(
           attributes.getProvider(), attributes.getProviderId());
 
       if (deactivatedUserOptional.isPresent()) {
-        // 탈퇴한 사용자 계정 재활성화
+        // 기존 탈퇴한 사용자 계정 재활성화 (제한 없음)
         user = deactivatedUserOptional.get();
         log.info("탈퇴한 계정 재활성화: provider={}, socialId={}, userId={}",
             attributes.getProvider(),
@@ -131,7 +131,13 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             LoggingUtils.maskNickname(user.getNickname()),
             LoggingUtils.maskNickname(attributes.getName()));
         user.reactivateAccount();
+
+        // 사용자 생성 데이터도 재활성화 (UserService 참조)
+        reactivateUserGeneratedData(user);
       } else {
+        // 3. 완전히 새로운 사용자 등록 전에만 재가입 제한 검증
+        validateReRegistration(attributes.getEmail());
+
         // 완전히 새로운 사용자 등록
         user = attributes.toEntity();
         user = userRepository.saveAndFlush(user);
@@ -143,6 +149,17 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
       }
     }
     return user;
+  }
+
+  /**
+   * 사용자 생성 데이터를 재활성화합니다.
+   *
+   * @param user 재활성화할 사용자
+   */
+  private void reactivateUserGeneratedData(User user) {
+    log.debug("사용자 생성 데이터 재활성화 시작: userId={}", LoggingUtils.maskUserId(user.getId()));
+
+    userService.reactivateUserGeneratedData(user);
   }
 
   /**

--- a/src/main/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserService.java
@@ -153,13 +153,26 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
   /**
    * 사용자 생성 데이터를 재활성화합니다.
+   * 데이터 재활성화 실패 시 로그인도 실패합니다.
    *
    * @param user 재활성화할 사용자
+   * @throws OAuth2AuthenticationException 데이터 재활성화 실패 시
    */
   private void reactivateUserGeneratedData(User user) {
     log.debug("사용자 생성 데이터 재활성화 시작: userId={}", LoggingUtils.maskUserId(user.getId()));
 
-    userService.reactivateUserGeneratedData(user);
+    try {
+      userService.reactivateUserGeneratedData(user);
+    } catch (Exception e) {
+      log.error("사용자 데이터 재활성화 실패: userId={}, error={}", 
+          LoggingUtils.maskUserId(user.getId()), e.getMessage(), e);
+      
+      // OAuth2AuthenticationException을 던져서 로그인 실패 처리
+      OAuth2Error oauth2Error = new OAuth2Error("data_reactivation_failed",
+          "탈퇴한 계정의 데이터를 복구하는 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+          null);
+      throw new OAuth2AuthenticationException(oauth2Error, e);
+    }
   }
 
   /**

--- a/src/main/java/org/nodystudio/nodybackend/service/comment/CommentService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/comment/CommentService.java
@@ -83,7 +83,7 @@ public class CommentService {
 
     // XSS 공격 방지를 위한 HTML sanitization
     String sanitizedContent = HtmlSanitizerUtil.sanitizeCommentContent(request.getContent());
-    
+
     // 멘션된 사용자 파싱 (원본 내용 기준)
     // Sanitizer가 멘션을 포함한 HTML을 제거할 수 있으므로, 반드시 원본 내용에서 멘션을 파싱해야 합니다.
     Set<User> mentionedUsers = parseMentionedUsers(request.getContent());
@@ -162,7 +162,7 @@ public class CommentService {
 
     // XSS 공격 방지를 위한 HTML sanitization
     String sanitizedContent = HtmlSanitizerUtil.sanitizeCommentContent(request.getContent());
-    
+
     // 멘션된 사용자 파싱 (원본 내용 기준)
     // Sanitizer가 멘션을 포함한 HTML을 제거할 수 있으므로, 반드시 원본 내용에서 멘션을 파싱해야 합니다.
     Set<User> newMentionedUsers = parseMentionedUsers(request.getContent());

--- a/src/main/java/org/nodystudio/nodybackend/service/log/LogService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/log/LogService.java
@@ -28,7 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
  * 사용자의 위치 기반 로그 관리 서비스
  *
  * <p>
- * 지리적 위치 정보를 활용한 로그 생성, 조회, 검색 기능을 제공합니다. 사용자 권한에 따라 공개/비공개 로그에 대한 접근을 제어하며, Haversine 공식을 사용한 반경
+ * 지리적 위치 정보를 활용한 로그 생성, 조회, 검색 기능을 제공합니다. 사용자 권한에 따라 공개/비공개 로그에 대한 접근을 제어하며,
+ * Haversine 공식을 사용한 반경
  * 기반 검색을 지원합니다.
  * </p>
  */
@@ -66,8 +67,8 @@ public class LogService {
     }
 
     // XSS 공격 방지를 위한 HTML sanitization
-    String sanitizedContent = request.getContent() != null 
-        ? HtmlSanitizerUtil.sanitize(request.getContent()) 
+    String sanitizedContent = request.getContent() != null
+        ? HtmlSanitizerUtil.sanitize(request.getContent())
         : null;
 
     LocationUtils.validateCoordinates(request.getLatitude(), request.getLongitude());
@@ -120,7 +121,8 @@ public class LogService {
    * 위치 기반 로그를 검색합니다.
    *
    * <p>
-   * 위치 정보가 제공된 경우 지정된 반경 내의 로그를 검색하고, 위치 정보가 없는 경우 전체 로그를 조회합니다. 사용자 권한에 따라 공개/비공개 로그 접근을 제어합니다.
+   * 위치 정보가 제공된 경우 지정된 반경 내의 로그를 검색하고, 위치 정보가 없는 경우 전체 로그를 조회합니다. 사용자 권한에 따라
+   * 공개/비공개 로그 접근을 제어합니다.
    * </p>
    *
    * @param searchRequest 검색 조건 (위치, 반경, 페이징 정보)
@@ -393,13 +395,11 @@ public class LogService {
   public int reactivateLogsByUserId(Long userId) {
     log.debug("사용자 로그 재활성화 시작: userId={}", LoggingUtils.maskUserId(userId));
 
-    List<Log> deactivatedLogs = logRepository.findDeactivatedLogsByUserId(userId);
-    deactivatedLogs.forEach(Log::reactivate);
-    logRepository.saveAll(deactivatedLogs);
+    int reactivatedCount = logRepository.reactivateByUserId(userId);
 
     log.debug("사용자 로그 재활성화 완료: userId={}, count={}",
-        LoggingUtils.maskUserId(userId), deactivatedLogs.size());
+        LoggingUtils.maskUserId(userId), reactivatedCount);
 
-    return deactivatedLogs.size();
+    return reactivatedCount;
   }
 }

--- a/src/main/java/org/nodystudio/nodybackend/service/thread/ThreadService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/thread/ThreadService.java
@@ -28,7 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
  * 스레드 관리 서비스
  *
  * <p>
- * 로그 연결 스레드와 독립 스레드의 생성, 조회, 수정, 삭제 기능을 제공합니다. 사용자 권한에 따라 공개/비공개 스레드에 대한 접근을 제어하며, 로그-스레드 연관관계 검증을
+ * 로그 연결 스레드와 독립 스레드의 생성, 조회, 수정, 삭제 기능을 제공합니다. 사용자 권한에 따라 공개/비공개 스레드에 대한 접근을
+ * 제어하며, 로그-스레드 연관관계 검증을
  * 수행합니다.
  * </p>
  */
@@ -66,8 +67,8 @@ public class ThreadService {
     }
 
     // XSS 공격 방지를 위한 HTML sanitization
-    String sanitizedContent = request.getContent() != null 
-        ? HtmlSanitizerUtil.sanitize(request.getContent().trim()) 
+    String sanitizedContent = request.getContent() != null
+        ? HtmlSanitizerUtil.sanitize(request.getContent().trim())
         : null;
 
     Thread thread = Thread.builder()
@@ -236,14 +237,13 @@ public class ThreadService {
     return log;
   }
 
-
   private Page<Thread> performSearch(ThreadSearchRequest searchRequest, User viewer,
       Pageable pageable) {
     // 키워드 검색이 있는 경우
     if (searchRequest.getKeyword() != null && !searchRequest.getKeyword().trim().isEmpty()) {
       return viewer != null
           ? threadRepository.searchThreadsByContentWithUser(searchRequest.getKeyword(),
-          viewer.getId(), pageable)
+              viewer.getId(), pageable)
           : threadRepository.searchPublicThreadsByContent(searchRequest.getKeyword(), pageable);
     }
 
@@ -251,7 +251,7 @@ public class ThreadService {
     if (searchRequest.getLogId() != null) {
       return viewer != null
           ? threadRepository.findThreadsByLogIdWithUser(searchRequest.getLogId(), viewer.getId(),
-          pageable)
+              pageable)
           : threadRepository.findPublicThreadsByLogIdOrderByCreatedAtDesc(searchRequest.getLogId(),
               pageable);
     }
@@ -325,13 +325,11 @@ public class ThreadService {
   public int reactivateThreadsByUserId(Long userId) {
     log.debug("사용자 스레드 재활성화 시작: userId={}", LoggingUtils.maskUserId(userId));
 
-    List<Thread> deactivatedThreads = threadRepository.findDeactivatedThreadsByUserId(userId);
-    deactivatedThreads.forEach(Thread::reactivate);
-    threadRepository.saveAll(deactivatedThreads);
+    int reactivatedCount = threadRepository.reactivateByUserId(userId);
 
     log.debug("사용자 스레드 재활성화 완료: userId={}, count={}",
-        LoggingUtils.maskUserId(userId), deactivatedThreads.size());
+        LoggingUtils.maskUserId(userId), reactivatedCount);
 
-    return deactivatedThreads.size();
+    return reactivatedCount;
   }
 }

--- a/src/test/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserServiceTest.java
@@ -24,6 +24,7 @@ import org.nodystudio.nodybackend.domain.enums.OAuthProvider;
 import org.nodystudio.nodybackend.domain.user.User;
 import org.nodystudio.nodybackend.dto.OAuthAttributes;
 import org.nodystudio.nodybackend.repository.UserRepository;
+import org.nodystudio.nodybackend.service.user.UserService;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistration.ProviderDetails;
@@ -44,7 +45,9 @@ class CustomOAuth2UserServiceTest {
   @Mock
   private UserRepository userRepository;
   @Mock
-  private OAuth2UserService<OAuth2UserRequest, OAuth2User> delegateUserService;
+  private UserService userService;
+  @Mock
+  private OAuth2UserService<OAuth2UserRequest, OAuth2User> mockDelegate;
   @Mock
   private OAuth2UserRequest userRequest;
   @Mock
@@ -92,7 +95,7 @@ class CustomOAuth2UserServiceTest {
     given(clientRegistration.getRegistrationId()).willReturn(registrationId);
     given(userRequest.getAccessToken()).willReturn(accessToken);
 
-    customOAuth2UserService = new CustomOAuth2UserService(userRepository, delegateUserService);
+    customOAuth2UserService = new CustomOAuth2UserService(userRepository, userService, mockDelegate);
   }
 
   @Test
@@ -102,7 +105,7 @@ class CustomOAuth2UserServiceTest {
     given(clientRegistration.getProviderDetails()).willReturn(providerDetails);
     given(providerDetails.getUserInfoEndpoint()).willReturn(userInfoEndpoint);
     given(userInfoEndpoint.getUserNameAttributeName()).willReturn(userNameAttributeName);
-    given(delegateUserService.loadUser(userRequest)).willReturn(mockOAuth2User);
+    given(mockDelegate.loadUser(userRequest)).willReturn(mockOAuth2User);
     given(mockOAuth2User.getAttributes()).willReturn(googleAttributes);
 
     given(userRepository.findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE,
@@ -131,7 +134,7 @@ class CustomOAuth2UserServiceTest {
     OAuth2User resultUser = customOAuth2UserService.loadUser(userRequest);
 
     // then
-    then(delegateUserService).should(times(1)).loadUser(userRequest);
+    then(mockDelegate).should(times(1)).loadUser(userRequest);
     then(userRepository).should(times(1))
         .findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE, socialId);
     then(userRepository).should(times(1)).saveAndFlush(any(User.class));
@@ -153,7 +156,7 @@ class CustomOAuth2UserServiceTest {
     given(clientRegistration.getProviderDetails()).willReturn(providerDetails);
     given(providerDetails.getUserInfoEndpoint()).willReturn(userInfoEndpoint);
     given(userInfoEndpoint.getUserNameAttributeName()).willReturn(userNameAttributeName);
-    given(delegateUserService.loadUser(userRequest)).willReturn(mockOAuth2User);
+    given(mockDelegate.loadUser(userRequest)).willReturn(mockOAuth2User);
     given(mockOAuth2User.getAttributes()).willReturn(googleAttributes);
     given(userRepository.findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE,
         "google_12345"))
@@ -163,7 +166,7 @@ class CustomOAuth2UserServiceTest {
     OAuth2User resultUser = customOAuth2UserService.loadUser(userRequest);
 
     // then
-    then(delegateUserService).should(times(1)).loadUser(userRequest);
+    then(mockDelegate).should(times(1)).loadUser(userRequest);
     then(userRepository).should(times(1))
         .findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE, socialId);
     then(userRepository).should(never()).save(any(User.class));
@@ -187,7 +190,7 @@ class CustomOAuth2UserServiceTest {
     OAuth2AuthenticationException expectedException = new OAuth2AuthenticationException(
         new OAuth2Error("test_error"),
         "Delegate Error");
-    given(delegateUserService.loadUser(userRequest)).willThrow(expectedException);
+    given(mockDelegate.loadUser(userRequest)).willThrow(expectedException);
 
     // when and then
     assertThatThrownBy(() -> customOAuth2UserService.loadUser(userRequest))
@@ -203,7 +206,7 @@ class CustomOAuth2UserServiceTest {
   void loadUser_shouldThrowOAuth2Exception_whenDelegateThrowsGeneralException() {
     // given
     RuntimeException expectedCause = new RuntimeException("Unexpected Delegate Error");
-    given(delegateUserService.loadUser(userRequest)).willThrow(expectedCause);
+    given(mockDelegate.loadUser(userRequest)).willThrow(expectedCause);
 
     // when and then
     assertThatThrownBy(() -> customOAuth2UserService.loadUser(userRequest))
@@ -220,13 +223,13 @@ class CustomOAuth2UserServiceTest {
   }
 
   @Test
-  @DisplayName("30일 이내 탈퇴한 이메일로 재가입 시도 시 OAuth2AuthenticationException 발생")
-  void loadUser_shouldThrowOAuth2Exception_whenReRegistrationRestricted() {
+  @DisplayName("30일 이내 탈퇴한 이메일로 완전히 새로운 계정 재가입 시도 시 예외 발생")
+  void loadUser_shouldThrowOAuth2Exception_whenNewAccountWithRecentlyDeactivatedEmail() {
     // given
     given(clientRegistration.getProviderDetails()).willReturn(providerDetails);
     given(providerDetails.getUserInfoEndpoint()).willReturn(userInfoEndpoint);
     given(userInfoEndpoint.getUserNameAttributeName()).willReturn(userNameAttributeName);
-    given(delegateUserService.loadUser(userRequest)).willReturn(mockOAuth2User);
+    given(mockDelegate.loadUser(userRequest)).willReturn(mockOAuth2User);
     given(mockOAuth2User.getAttributes()).willReturn(googleAttributes);
 
     // 활성 사용자 없음
@@ -234,12 +237,16 @@ class CustomOAuth2UserServiceTest {
         "google_12345"))
         .willReturn(Optional.empty());
 
-    // 30일 이내 탈퇴한 사용자 존재
+    // 기존 소셜 계정 없음 (완전히 새로운 사용자)
+    given(userRepository.findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345"))
+        .willReturn(Optional.empty());
+
+    // 30일 이내 탈퇴한 이메일 사용자 존재 (다른 소셜 ID)
     User recentlyDeactivatedUser = User.builder()
         .id(3L)
         .provider(OAuthProvider.GOOGLE)
-        .socialId("different_social_id")
-        .email("test@example.com")
+        .socialId("different_social_id") // 다른 소셜 ID
+        .email("test@example.com") // 동일한 이메일
         .nickname("Deactivated User")
         .isActive(false)
         .build();
@@ -254,31 +261,29 @@ class CustomOAuth2UserServiceTest {
         .isInstanceOf(OAuth2AuthenticationException.class)
         .hasMessageContaining("해당 이메일로는 탈퇴 후 30일 동안 재가입할 수 없습니다");
 
+    // 새로운 로직 순서 확인: 탈퇴한 사용자 확인 > 재가입 제한 검증
     then(userRepository).should(times(1))
         .findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE, "google_12345");
+    then(userRepository).should(times(1))
+        .findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345");
     then(userRepository).should(times(1))
         .findByEmailAndDeletedAtAfter(eq("test@example.com"), any(LocalDateTime.class));
     then(userRepository).should(never()).saveAndFlush(any(User.class));
   }
 
   @Test
-  @DisplayName("탈퇴한 사용자가 30일 후 재가입 시도 시 계정 재활성화")
-  void loadUser_shouldReactivateAccount_whenDeactivatedUserReturns() {
+  @DisplayName("탈퇴한 사용자가 재로그인 시 계정 및 데이터 재활성화")
+  void loadUser_shouldReactivateAccountAndData_whenDeactivatedUserReturns() {
     // given
     given(clientRegistration.getProviderDetails()).willReturn(providerDetails);
     given(providerDetails.getUserInfoEndpoint()).willReturn(userInfoEndpoint);
     given(userInfoEndpoint.getUserNameAttributeName()).willReturn(userNameAttributeName);
-    given(delegateUserService.loadUser(userRequest)).willReturn(mockOAuth2User);
+    given(mockDelegate.loadUser(userRequest)).willReturn(mockOAuth2User);
     given(mockOAuth2User.getAttributes()).willReturn(googleAttributes);
 
     // 활성 사용자 없음
     given(userRepository.findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE,
         "google_12345"))
-        .willReturn(Optional.empty());
-
-    // 재가입 제한 없음 (30일 지남)
-    given(userRepository.findByEmailAndDeletedAtAfter(eq("test@example.com"),
-        any(LocalDateTime.class)))
         .willReturn(Optional.empty());
 
     // 탈퇴한 사용자 존재
@@ -299,19 +304,72 @@ class CustomOAuth2UserServiceTest {
     OAuth2User resultUser = customOAuth2UserService.loadUser(userRequest);
 
     // then
-    then(userRepository).should(times(1))
-        .findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE, "google_12345");
-    then(userRepository).should(times(1))
-        .findByEmailAndDeletedAtAfter(eq("test@example.com"), any(LocalDateTime.class));
-    then(userRepository).should(times(1))
-        .findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345");
-    then(userRepository).should(never()).saveAndFlush(any(User.class));
-
-    // 계정이 재활성화되었는지 확인 (30일 유예기간 완전 복구)
+    // 계정이 재활성화되었는지 확인
     assertThat(deactivatedUser.getIsActive()).isTrue();
     assertThat(deactivatedUser.getDeletedAt()).isNull();
     assertThat(deactivatedUser.getNickname()).isEqualTo("Old Name"); // 기존 닉네임 유지
     assertThat(deactivatedUser.getEmail()).isEqualTo("old@example.com"); // 기존 이메일 유지
+
+    // 사용자 생성 데이터 재활성화 확인 (UserService 통해)
+    then(userService).should(times(1)).reactivateUserGeneratedData(deactivatedUser);
+
+    // 기본 검증
+    then(userRepository).should(times(1))
+        .findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE, "google_12345");
+    then(userRepository).should(times(1))
+        .findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345");
+    then(userRepository).should(never()).saveAndFlush(any(User.class));
+
+    assertThat(resultUser).isNotNull();
+    assertThat(resultUser.getAuthorities()).extracting(GrantedAuthority::getAuthority)
+        .containsExactly("ROLE_USER");
+  }
+
+  @Test
+  @DisplayName("30일 이내 탈퇴한 이메일이지만 기존 소셜 계정으로 재로그인 시 재활성화 허용")
+  void loadUser_shouldReactivateAccount_whenSameSocialAccountReturnsWithin30Days() {
+    // given
+    given(clientRegistration.getProviderDetails()).willReturn(providerDetails);
+    given(providerDetails.getUserInfoEndpoint()).willReturn(userInfoEndpoint);
+    given(userInfoEndpoint.getUserNameAttributeName()).willReturn(userNameAttributeName);
+    given(mockDelegate.loadUser(userRequest)).willReturn(mockOAuth2User);
+    given(mockOAuth2User.getAttributes()).willReturn(googleAttributes);
+
+    // 활성 사용자 없음
+    given(userRepository.findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE,
+        "google_12345"))
+        .willReturn(Optional.empty());
+
+    // 탈퇴한 사용자 존재 (동일한 소셜 계정)
+    User deactivatedUser = User.builder()
+        .id(5L)
+        .provider(OAuthProvider.GOOGLE)
+        .socialId("google_12345") // 동일한 소셜 ID
+        .email("test@example.com") // 동일한 이메일
+        .nickname("Old Name")
+        .isActive(false)
+        .build();
+    deactivatedUser.deactivateAccount();
+
+    given(userRepository.findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345"))
+        .willReturn(Optional.of(deactivatedUser));
+
+    // when
+    OAuth2User resultUser = customOAuth2UserService.loadUser(userRequest);
+
+    // then
+    // 재가입 제한 검증은 호출되지 않음 (기존 소셜 계정이므로)
+    then(userRepository).should(never())
+        .findByEmailAndDeletedAtAfter(anyString(), any(LocalDateTime.class));
+
+    // 계정이 재활성화되었는지 확인
+    assertThat(deactivatedUser.getIsActive()).isTrue();
+    assertThat(deactivatedUser.getDeletedAt()).isNull();
+    assertThat(deactivatedUser.getNickname()).isEqualTo("Old Name"); // 기존 닉네임 유지
+    assertThat(deactivatedUser.getEmail()).isEqualTo("test@example.com"); // 기존 이메일 유지
+
+    // 데이터 재활성화 확인 (UserService 통해)
+    then(userService).should(times(1)).reactivateUserGeneratedData(deactivatedUser);
 
     assertThat(resultUser).isNotNull();
     assertThat(resultUser.getAuthorities()).extracting(GrantedAuthority::getAuthority)

--- a/src/test/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
@@ -110,13 +111,13 @@ class CustomOAuth2UserServiceTest {
 
     given(userRepository.findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE,
         "google_12345")).willReturn(
-        Optional.empty());
+            Optional.empty());
     given(userRepository.findByEmailAndDeletedAtAfter(anyString(),
         any(LocalDateTime.class))).willReturn(
-        Optional.empty());
+            Optional.empty());
     given(
         userRepository.findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345")).willReturn(
-        Optional.empty());
+            Optional.empty());
     given(userRepository.saveAndFlush(any(User.class))).willAnswer(invocation -> {
       User userToSave = invocation.getArgument(0);
 
@@ -341,18 +342,18 @@ class CustomOAuth2UserServiceTest {
         .willReturn(Optional.empty());
 
     // 탈퇴한 사용자 존재 (동일한 소셜 계정)
-    User deactivatedUser = User.builder()
-        .id(5L)
+    User anotherDeactivatedUser = User.builder()
+        .id(7L)
         .provider(OAuthProvider.GOOGLE)
         .socialId("google_12345") // 동일한 소셜 ID
         .email("test@example.com") // 동일한 이메일
         .nickname("Old Name")
         .isActive(false)
         .build();
-    deactivatedUser.deactivateAccount();
+    anotherDeactivatedUser.deactivateAccount();
 
     given(userRepository.findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345"))
-        .willReturn(Optional.of(deactivatedUser));
+        .willReturn(Optional.of(anotherDeactivatedUser));
 
     // when
     OAuth2User resultUser = customOAuth2UserService.loadUser(userRequest);
@@ -363,16 +364,63 @@ class CustomOAuth2UserServiceTest {
         .findByEmailAndDeletedAtAfter(anyString(), any(LocalDateTime.class));
 
     // 계정이 재활성화되었는지 확인
-    assertThat(deactivatedUser.getIsActive()).isTrue();
-    assertThat(deactivatedUser.getDeletedAt()).isNull();
-    assertThat(deactivatedUser.getNickname()).isEqualTo("Old Name"); // 기존 닉네임 유지
-    assertThat(deactivatedUser.getEmail()).isEqualTo("test@example.com"); // 기존 이메일 유지
+    assertThat(anotherDeactivatedUser.getIsActive()).isTrue();
+    assertThat(anotherDeactivatedUser.getDeletedAt()).isNull();
+    assertThat(anotherDeactivatedUser.getNickname()).isEqualTo("Old Name"); // 기존 닉네임 유지
+    assertThat(anotherDeactivatedUser.getEmail()).isEqualTo("test@example.com"); // 기존 이메일 유지
 
     // 데이터 재활성화 확인 (UserService 통해)
-    then(userService).should(times(1)).reactivateUserGeneratedData(deactivatedUser);
+    then(userService).should(times(1)).reactivateUserGeneratedData(anotherDeactivatedUser);
 
     assertThat(resultUser).isNotNull();
     assertThat(resultUser.getAuthorities()).extracting(GrantedAuthority::getAuthority)
         .containsExactly("ROLE_USER");
   }
+
+  @Test
+  @DisplayName("데이터 재활성화 실패 시 로그인 실패")
+  void loadUser_shouldFailLogin_whenDataReactivationFails() {
+    // given
+    given(clientRegistration.getProviderDetails()).willReturn(providerDetails);
+    given(providerDetails.getUserInfoEndpoint()).willReturn(userInfoEndpoint);
+    given(userInfoEndpoint.getUserNameAttributeName()).willReturn(userNameAttributeName);
+    given(mockDelegate.loadUser(userRequest)).willReturn(mockOAuth2User);
+    given(mockOAuth2User.getAttributes()).willReturn(googleAttributes);
+
+    // 활성 사용자 없음
+    given(userRepository.findByProviderAndSocialIdAndIsActiveTrue(OAuthProvider.GOOGLE,
+        "google_12345"))
+        .willReturn(Optional.empty());
+
+    // 탈퇴한 사용자 존재
+    User deactivatedUser = User.builder()
+        .id(6L)
+        .provider(OAuthProvider.GOOGLE)
+        .socialId("google_12345")
+        .email("test@example.com")
+        .nickname("Test User")
+        .isActive(false)
+        .build();
+    deactivatedUser.deactivateAccount();
+
+    given(userRepository.findByProviderAndSocialId(OAuthProvider.GOOGLE, "google_12345"))
+        .willReturn(Optional.of(deactivatedUser));
+
+    // 데이터 재활성화 실패 설정
+    doThrow(new RuntimeException("데이터베이스 연결 실패"))
+        .when(userService).reactivateUserGeneratedData(deactivatedUser);
+
+    // when & then
+    assertThatThrownBy(() -> customOAuth2UserService.loadUser(userRequest))
+        .isInstanceOf(OAuth2AuthenticationException.class)
+        .satisfies(exception -> {
+          OAuth2AuthenticationException oauthException = (OAuth2AuthenticationException) exception;
+          assertThat(oauthException.getError().getErrorCode()).isEqualTo("data_reactivation_failed");
+          assertThat(oauthException.getError().getDescription())
+              .isEqualTo("탈퇴한 계정의 데이터를 복구하는 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+          assertThat(oauthException.getCause()).isInstanceOf(RuntimeException.class);
+          assertThat(oauthException.getCause().getMessage()).isEqualTo("데이터베이스 연결 실패");
+        });
+  }
+
 }


### PR DESCRIPTION
# Pull Request

## 🎯 문제 정의 및 배경

### 🔗 관련 이슈

<!-- 관련 이슈 번호를 연결해주세요 (예: Fixes #123, Closes #456) -->

- OAuth2 탈퇴 사용자 재로그인 시 탈퇴 취소 기능 개선

### 📌 문제 설명

탈퇴한 사용자가 OAuth2로 재로그인할 때 계정 재활성화는 성공하지만, 사용자가 생성한 데이터(로그, 스레드)의 재활성화가 누락되는 문제가 있었습니다.

### 🎭 문제 발생 배경

기존 구현에서는 탈퇴 사용자 재로그인 시 사용자 계정만 재활성화하고, 관련 데이터(로그, 스레드)의 재활성화는 처리하지 않았습니다.
1. **사용자 계정 재활성화**: `user.reactivateAccount()` 정상 실행
2. **사용자 데이터 재활성화**: `reactivateUserGeneratedData()` 기능 누락

이로 인해 사용자는 로그인은 되지만 기존에 작성했던 로그와 스레드가 여전히 비활성화 상태로 남아있어, **탈퇴 취소 기능이 불완전하게 작동**하는 문제가 발생했습니다.

---

## 🔍 원인 분석

### 🐛 근본 원인

CustomOAuth2UserService에서 탈퇴한 사용자의 재로그인을 처리할 때, 사용자 계정만 재활성화하고 관련 데이터(로그, 스레드)의 재활성화는 처리하지 않았기 때문입니다. `CustomOAuth2UserService`에서 `user.reactivateAccount()`로 사용자 계정만 재활성화하고, 사용자 생성 데이터의 재활성화 로직(`reactivateUserGeneratedData()`)이 호출되지 않아 부분적으로만 처리되는 상황이었습니다.

### 🔬 디버깅 과정

1. OAuth2 로그인 플로우 분석 및 탈퇴 사용자 재로그인 시나리오 테스트
2. CustomOAuth2UserService 로직 검토 및 사용자 데이터 복구 로직 부재 확인
3. Repository 레이어에서 관련 데이터 재활성화 메서드 필요성 파악

### 💭 고려했던 가능성들

- OAuth2 인증 프로세스 자체의 문제
- 데이터베이스 트랜잭션 처리 문제
- 사용자 서비스 레이어의 의존성 문제

---

## 💡 해결 방안

### 🤔 검토한 해결 방법들

#### 방법 1: Service 레이어에서 재활성화 로직 처리

- **장점**: 비즈니스 로직의 캡슐화, 재사용성
- **단점**: OAuth2UserService와 UserService 간 순환 의존성 위험

#### 방법 2: Repository 레이어에 재활성화 메서드 추가 후 OAuth2UserService에서 직접 호출

- **장점**: 단순하고 직접적인 해결, 순환 의존성 방지
- **단점**: OAuth2UserService에 비즈니스 로직이 다소 증가

### ✅ 선택한 방법과 이유

**방법 2를 선택**했습니다. Repository 레이어에 재활성화 메서드를 추가하고, CustomOAuth2UserService에 UserService 의존성을 추가하여 사용자 재활성화와 관련 데이터 복구를 함께 처리하도록 구현했습니다. 이는 OAuth2 로그인 컨텍스트에서 필요한 모든 재활성화 작업을 한 곳에서 처리할 수 있어 일관성 있고 명확한 로직을 유지할 수 있습니다.

관련 기능이 많아질 경우 Component Service 아키텍처를 활용한 리팩토링도 고려할 수 있습니다.

---

## 📊 결과 및 영향

### 🚀 개선 사항

- 탈퇴한 사용자의 OAuth2 재로그인 시 완전한 데이터 복구
- 탈퇴 취소 후 기존 데이터 즉시 접근 가능하도록 개선
- 트랜잭션 기반 안전한 재활성화 처리하여 일관성을 보장합니다.

### ⚠️ 주의 사항

- OAuth2 인증을 통해서만 재활성화 가능하므로 보안성 유지
- 대용량 데이터를 가진 사용자의 경우 재활성화 시간이 다소 소요될 수 있음

### 📈 성능 영향

일반적인 사용자의 경우 재활성화 작업이 매우 빠르게 처리되며, 정상적인 OAuth2 로그인 성능에 미치는 영향은 미미합니다.

---

## 📝 구현 세부사항

### 📁 주요 변경 내용

1. **Repository 레이어**: LogRepository와 ThreadRepository에 사용자별 데이터 재활성화 메서드 추가
2. **OAuth2 서비스**: CustomOAuth2UserService에 UserService 의존성 추가 및 재활성화 로직 구현
3. **테스트 코드**: 재활성화 시나리오에 대한 포괄적인 테스트 케이스 추가

---

## 🔧 기술적 변경 사항

### 📁 주요 변경 파일

- `src/main/java/org/nodystudio/nodybackend/repository/LogRepository.java`
- `src/main/java/org/nodystudio/nodybackend/repository/ThreadRepository.java`
- `src/main/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserService.java`
- `src/test/java/org/nodystudio/nodybackend/service/auth/CustomOAuth2UserServiceTest.java`

### 🛠️ API 변경 사항

API 엔드포인트의 변경은 없으며, OAuth2 로그인 플로우의 내부 로직만 개선되었습니다.


### 🔐 보안 관련 변경

- [x] 인증/인가 로직 변경
- [x] OAuth2 설정 변경

---

## ✅ 체크리스트

### 📋 코드 품질

- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 주석과 콘솔 로그를 제거했습니다
- [x] 적절한 예외 처리를 구현했습니다
- [x] API 응답 형식이 일관성 있게 구현되었습니다 (`ApiResponse<T>` 사용)

### 🧪 테스트

- [x] 새로운 기능에 대한 단위 테스트를 작성했습니다
- [x] API 테스트 케이스를 추가했습니다

### 📖 문서화

- [x] 코드 주석이 적절히 작성되었습니다
- [x] 변경 사항에 대한 문서를 작성했습니다

### 🔧 설정 및 환경

- [x] 개발 환경에서 정상 동작을 확인했습니다
- [x] 프로덕션 환경 설정을 고려했습니다
- [x] 환경별 설정 파일이 적절히 구성되었습니다 (dev, prod)
- [x] 의존성 추가 시 버전 충돌을 확인했습니다

---

## 🧪 테스트 결과

### 🔍 테스트 시나리오

1. 활성 사용자 OAuth2 로그인 - 기존 로직 정상 동작 확인
2. 탈퇴한 사용자 OAuth2 재로그인 - 사용자 및 관련 데이터 재활성화 확인
3. 신규 사용자 OAuth2 가입 - 새로운 사용자 등록 프로세스 정상 동작 확인

### 📊 테스트 커버리지

- [x] 단위 테스트 커버리지: 추가된 로직에 대한 테스트 완료
- [x] 통합 테스트 완료

---

## 📸 스크린샷 / 로그

OAuth2 재로그인 테스트 시 사용자 재활성화 및 관련 데이터 복구가 정상적으로 처리되는 것을 확인했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 소셜 계정 재로그인 시 비활성화된 계정과 해당 사용자가 생성한 데이터(로그, 스레드 등)가 함께 복구되는 기능이 추가되었습니다.
  * 사용자별 비활성화된 로그와 스레드를 한 번에 복구하는 기능이 도입되어 복구 처리 속도가 향상되었습니다.

* **버그 수정**
  * 비활성화된 계정의 이메일로 재가입 시 재가입 제한 및 계정 복구 로직이 개선되었습니다.

* **테스트**
  * 계정 재활성화 및 재가입 제한 관련 테스트가 보강되고, 사용자 생성 데이터 복구 여부에 대한 테스트가 추가되었습니다.
  * 사용자 데이터 복구 실패 시 로그인 실패 처리에 대한 테스트가 새로 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->