### PR TITLE
fix(log): /api/logs 위치 기반 검색 API 복합적 오류 수정

### DIFF
--- a/src/main/java/org/nodystudio/nodybackend/dto/log/LogSearchRequest.java
+++ b/src/main/java/org/nodystudio/nodybackend/dto/log/LogSearchRequest.java
@@ -1,5 +1,7 @@
 package org.nodystudio.nodybackend.dto.log;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Max;
@@ -10,6 +12,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.nodystudio.nodybackend.domain.enums.LogSortField;
 import org.nodystudio.nodybackend.domain.enums.SortDirection;
 
@@ -21,6 +24,7 @@ import org.nodystudio.nodybackend.domain.enums.SortDirection;
  * </p>
  */
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -91,6 +95,17 @@ public class LogSearchRequest {
    * 기본값: DESC
    * </p>
    */
+  @Schema(description = "정렬 방향 (ASC 또는 DESC)", defaultValue = "DESC")
   @Builder.Default
   private SortDirection sortDirection = SortDirection.DESC;
+
+  /**
+   * 위치 정보(위도, 경도)가 모두 유효한지 확인합니다.
+   *
+   * @return 위치 정보가 모두 있으면 true, 그렇지 않으면 false
+   */
+  @JsonIgnore
+  public boolean isLocationSearch() {
+    return latitude != null && longitude != null;
+  }
 }

--- a/src/main/java/org/nodystudio/nodybackend/service/log/LogService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/log/LogService.java
@@ -136,11 +136,15 @@ public class LogService {
         searchRequest.getRadiusKm(), userEmail);
 
     User viewer = userEmail != null ? findUserByEmail(userEmail) : null;
-    Pageable pageable = createPageable(searchRequest);
 
-    Page<Log> logs = hasLocationInfo(searchRequest)
-        ? searchByLocation(searchRequest, viewer, pageable)
-        : searchAllLogs(viewer, pageable);
+    // 위치 기반 검색 시 Native Query의 ORDER BY를 사용하므로 Pageable에서 정렬 제외
+    Pageable pageable = createPageable(searchRequest, searchRequest.isLocationSearch());
+
+    Page<Log> logs = searchLogs(searchRequest, viewer, pageable, searchRequest.isLocationSearch());
+
+    logs.getContent().forEach(log -> {
+      log.getMediaUrls().size();
+    });
 
     log.info("로그 검색 완료 - 총 {}건", logs.getTotalElements());
     return logs.map(LogResponse::from);
@@ -197,11 +201,24 @@ public class LogService {
   }
 
   /**
-   * 검색 조건에 따라 페이징 객체를 생성합니다.
+   * 검색 조건에 따라 페이징(Paging) 및 정렬(Sort) 설정을 담은 {@link Pageable} 객체를 생성합니다.
+   *
+   * <p>
+   * 이 메서드는 위치 기반 검색 여부에 따라 정렬 객체의 포함 여부를 동적으로 결정합니다.
+   * 위치 검색 시에는 거리순 정렬이 데이터베이스의 네이티브 쿼리에서 직접 처리되므로,
+   * {@code Pageable} 객체에는 별도의 정렬 정보를 포함하지 않습니다.
+   * 그 외의 경우에는 요청된 정렬 기준을 적용합니다.
+   * </p>
+   *
+   * @param searchRequest    페이징 및 정렬 정보가 포함된 검색 요청 객체
+   * @param isLocationSearch 위치 기반 검색 여부를 나타내는 플래그
+   * @return 생성된 {@code Pageable} 객체
    */
-  private Pageable createPageable(LogSearchRequest searchRequest) {
+  private Pageable createPageable(LogSearchRequest searchRequest, boolean isLocationSearch) {
     Sort sort = createSort(searchRequest.getSortBy(), searchRequest.getSortDirection());
-    return PageRequest.of(searchRequest.getPage(), searchRequest.getSize(), sort);
+    return isLocationSearch
+        ? PageRequest.of(searchRequest.getPage(), searchRequest.getSize())
+        : PageRequest.of(searchRequest.getPage(), searchRequest.getSize(), sort);
   }
 
   /**
@@ -254,13 +271,6 @@ public class LogService {
   }
 
   /**
-   * 검색 요청에 위치 정보가 포함되어 있는지 확인합니다.
-   */
-  private boolean hasLocationInfo(LogSearchRequest searchRequest) {
-    return searchRequest.getLatitude() != null && searchRequest.getLongitude() != null;
-  }
-
-  /**
    * 거리 정렬 방향을 결정합니다.
    */
   private String getDistanceSortDirection(LogSearchRequest searchRequest) {
@@ -300,9 +310,36 @@ public class LogService {
   }
 
   /**
-   * 전체 로그 검색을 수행합니다. 사용자 권한에 따라 조회 범위를 제한합니다.
+   * 검색 조건에 따라 로그를 조회하는 내부 헬퍼 메서드입니다.
+   *
+   * <p>
+   * 위치 기반 검색과 전체 검색을 분기하여 처리합니다.
+   * <ul>
+   * <li><b>위치 기반 검색 (isLocationSearch = true):</b> {@link #searchByLocation} 메서드를
+   * 호출하여 반경 내 로그를 검색합니다.</li>
+   * <li><b>전체 검색 (isLocationSearch = false):</b>
+   * <ul>
+   * <li><b>로그인 사용자 (viewer != null):</b> 모든 공개 로그와 사용자 자신의 비공개 로그을 조회합니다.</li>
+   * <li><b>비로그인 사용자 (viewer == null):</b> 모든 공개 로그만 조회합니다.</li>
+   * </ul>
+   * </li>
+   * </ul>
+   * </p>
+   *
+   * @param searchRequest    검색 조건이 담긴 요청 객체
+   * @param viewer           조회하는 사용자 정보 (null일 경우 비로그인 사용자)
+   * @param pageable         페이징 및 정렬 정보
+   * @param isLocationSearch 위치 기반 검색 여부 플래그
+   * @return 검색 조건에 맞는 페이징 처리된 로그 목록
    */
-  private Page<Log> searchAllLogs(User viewer, Pageable pageable) {
+  private Page<Log> searchLogs(LogSearchRequest searchRequest, User viewer, Pageable pageable,
+      boolean isLocationSearch) {
+
+    if (isLocationSearch) {
+      return searchByLocation(searchRequest, viewer, pageable);
+    }
+
+    // 전체 로그 검색
     if (viewer != null) {
       // 로그인 사용자: 공개 로그 + 본인 비공개 로그
       return logRepository.findPublicOrUserLogsOrderByCreatedAtDesc(viewer.getId(), pageable);

--- a/src/test/java/org/nodystudio/nodybackend/security/handler/OAuth2LoginSuccessHandlerTest.java
+++ b/src/test/java/org/nodystudio/nodybackend/security/handler/OAuth2LoginSuccessHandlerTest.java
@@ -104,6 +104,7 @@ class OAuth2LoginSuccessHandlerTest {
         "http://localhost:3000,https://localhost:3000");
     ReflectionTestUtils.setField(successHandler, "cookieDomain", "localhost");
     ReflectionTestUtils.setField(successHandler, "cookieSameSite", "Strict");
+    ReflectionTestUtils.setField(successHandler, "cookieSecure", true);
 
     given(clientRegistrationRepository.findByRegistrationId(
         OAuthProvider.GOOGLE.getValue())).willReturn(
@@ -208,6 +209,7 @@ class OAuth2LoginSuccessHandlerTest {
     // 유효하지 않은 리다이렉트 URL 설정
     ReflectionTestUtils.setField(successHandler, "redirectUrl",
         "http://malicious-site.com/callback");
+    ReflectionTestUtils.setField(successHandler, "cookieSecure", true);
 
     // when
     successHandler.onAuthenticationSuccess(request, response, authentication);


### PR DESCRIPTION
## 🐛 수정된 버그

### 문제 설명
`/api/logs` 엔드포인트를 통한 위치 기반 검색 기능에서 세 가지의 오류가 연속해서 발생하여 해당 API가 동작하지 않는 상황이었습니다. 사용자가 특정 위치(위도, 경도)와 반경을 지정하여 주변 로그를 검색하려고 할 때 다음과 같은 오류가 발생했습니다.

1. **MethodArgumentNotValidException**
사용자가 올바른 위도, 경도, 반경 값을 포함한 요청을 보냈음에도, `LogSearchRequest` DTO 클래스에 Lombok의 `@Setter` 어노테이션이 누락되어 있어 Spring MVC의 `@ModelAttribute` 파라미터 바인딩이 실패했습니다. 이로 인해 요청 파라미터가 DTO 객체의 필드에 주입되지 않아 `latitude`와 `longitude` 필드가 null로 처리되었고, Bean Validation에 의해 `MethodArgumentNotValidException`이 발생했습니다.

2. **LazyInitializationException**
첫 번째 문제를 `@Setter` 추가로 해결한 후, JPA의 지연 로딩(Lazy Loading) 전략과 Native Query의 상호작용으로 인한 새로운 문제가 발생했습니다. `LogRepository`의 `findByLocationWithinRadius` Native Query는 `logs` 테이블만 조회하므로 `Log` 엔티티의 `@ElementCollection`으로 매핑된 `mediaUrls` 필드는 초기화되지 않은 프록시 상태로 남았습니다. 서비스 계층의 `@Transactional` 범위가 끝난 후 컨트롤러에서 응답을 JSON으로 직렬화하는 과정에서 이 프록시에 접근하려 했지만 이미 데이터베이스 세션이 닫혀있어 `LazyInitializationException`이 발생했습니다.

3. **SQL 'Unknown column' Error**
지연 로딩 문제를 해결하려는 과정에서 Native Query의 정렬 메커니즘과 JPA의 `Pageable` 객체 간 충돌이 발생했습니다. Native Query에서는 이미 거리(`distance`) 기준의 `ORDER BY` 절이 포함되어 있는데, 동시에 `LogService`에서 `Pageable` 객체를 생성할 때 `createdAt` 기준의 정렬을 추가로 시도한 것이 원인이었습니다. `Pageable`이 JPA 엔티티의 필드명(`createdAt`)을 사용하지만 Native Query는 실제 데이터베이스 컬럼명(`created_at`)을 기대하므로, 이름 불일치로 인해 `Unknown column 'l.createdAt' in 'order clause'` SQL 오류가 발생했습니다.

## 🔧 변경 사항

### 수정 내용

#### 1. LogSearchRequest DTO 개선
- **파라미터 바인딩 문제 해결**
`LogSearchRequest` 클래스에 Lombok의 `@Setter` 어노테이션을 추가하여 Spring MVC가 HTTP 요청 파라미터를 DTO 객체의 필드에 올바르게 주입할 수 있도록 수정했습니다.

- **위치 검색 판별 로직 추가**
`isLocationSearch()` 메서드를 추가하여 위도와 경도 값이 모두 존재하는지 확인하는 메서드를 구현했습니다. 이 메서드는 `@JsonIgnore` 어노테이션을 사용하여 JSON 직렬화에서 제외되고 서비스 레이어에서 위치 기반 검색과 전체 검색을 구분하는 데 사용됩니다.

- **API 문서화 품질 향상**
`sortDirection` 필드에 `@Schema` 어노테이션을 추가하여 OpenAPI 문서에서 해당 필드의 설명과 기본값을 명확히 표시하도록 개선했습니다.

#### 2. LogService 검색 로직 리팩토링
- **통합 검색 메서드 구현**
기존에 `searchByLocation()`과 `searchAllLogs()` 두 개의 별개 메서드로 분리되어 있던 로직을 `searchLogs()` 하나의 통합 메서드로 리팩토링했습니다. `isLocationSearch` 플래그를 받아 위치 기반 검색과 전체 검색을 일관된 방식으로 처리하도록 작성하여 코드 중복을 제거했습니다.

- **Native Query와 Pageable 정렬 충돌 해결**
`createPageable()` 메서드를 오버로드하여 `isLocationSearch` 매개변수를 추가했습니다. 위치 기반 검색인 경우에는 Native Query에서 이미 거리순 정렬을 수행하므로 `Pageable` 객체에 정렬 정보를 포함하지 않는 `PageRequest.of(page, size)` 형태로 생성하고, 일반 검색인 경우에만 요청된 정렬 조건을 포함하는 `PageRequest.of(page, size, sort)` 형태로 생성하도록 분기 처리했습니다.

- **지연 로딩 예외 사전 방지**
트랜잭션이 여전히 활성 상태인 서비스 레이어에서 `logs.getContent().forEach(log -> log.getMediaUrls().size())` 코드를 추가하여 `mediaUrls` 컬렉션을 명시적으로 초기화하도록 구현했습니다. 컬렉션의 `size()` 메서드를 호출함으로써 지연 로딩된 데이터를 실제로 데이터베이스에서 조회하도록 적용해 이후 트랜잭션이 종료되어도 JSON 직렬화 과정에서 `LazyInitializationException`이 발생하지 않도록 예외를 방지했습니다.

- **코드 문서화 및 가독성 향상**
모든 주요 메서드에 상세한 JavaDoc 주석을 추가하여 각 메서드의 목적, 매개변수, 반환값, 그리고 특별한 처리 로직에 대한 설명을 포함했습니다. 상세한 설명을 포함하여 향후 코드를 이해하고 유지보수할 때 도움이 될 수 있도록 작성했습니다.

### 영향 범위
- `/api/logs` 위치 기반 검색 API 엔드포인트
- `LogSearchRequest` DTO 클래스
- `LogService` 클래스의 로그 검색 관련 메서드들

## 🧪 테스트

### 테스트 완료 항목
- [x] 단위 테스트 통과
- [x] 통합 테스트 통과  
- [x] 수동 테스트 완료
- [x] 회귀 테스트 확인

### 테스트 시나리오
1. **재현 테스트**: 
   - 수정 전: `MethodArgumentNotValidException`, `LazyInitializationException`, `Unknown column 'l.createdAt'` 오류 연쇄 발생 확인
   - 수정 후: 정상적인 200 OK 응답과 위치 반경 내 로그 데이터 반환 확인

2. **관련 기능 테스트**:
   - 전체 로그 검색 기능 정상 동작 확인
   - 인증된 사용자/비인증 사용자별 로그 조회 권한 확인
   - 페이징 및 정렬 기능 정상 동작 확인

3. **엣지 케이스 테스트**:
   - 잘못된 위도/경도 값 입력 시 적절한 검증 오류 반환 확인
   - 반경 범위를 벗어난 값 입력 시 검증 동작 확인
   - 빈 결과 조회 시 정상적인 빈 배열 반환 확인

## 📸 스크린샷/로그

### Before (수정 전)
```json
// 1. MethodArgumentNotValidException
{
  "message": "Validation failed for argument [0] ... with 2 errors: [Field error in object 'logSearchRequest' on field 'latitude': rejected value [null] ... default message [위도는 필수입니다.]] [Field error in object 'logSearchRequest' on field 'longitude': rejected value [null] ... default message [경도는 필수입니다.]]"
}

// 2. LazyInitializationException  
{
  "message": "failed to lazily initialize a collection of role: org.nodystudio.nodybackend.domain.log.Log.mediaUrls: could not initialize proxy - no Session"
}

// 3. SQL 'Unknown column' Error
{
  "message": "... [Unknown column 'l.createdAt' in 'order clause'] [n/a]; SQL [n/a]"
}
```

### After (수정 후)
```bash
curl --location 'http://localhost:8080/api/logs?latitude=-54.15&longitude=175.67&radiusKm=50.35&isPublic=true&page=0&size=11&sortBy=CREATED_AT&sortDirection=ASC' \
--header 'Authorization: Bearer <JWT_TOKEN>'
```

**응답**: `200 OK` 상태코드와 함께 정상적인 로그 데이터 반환

### 참고 자료
- [Spring Boot Data JPA Native Query 가이드](https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#jpa.query-methods.at-query)
- [Hibernate LazyInitializationException 해결 방법](https://vladmihalcea.com/the-best-way-to-handle-the-lazyinitializationexception/)
- [Spring MVC @ModelAttribute 바인딩 원리](https://docs.spring.io/spring-framework/docs/current/reference/html/web.html#mvc-ann-modelattrib-method-args)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * 로그 검색 요청의 정렬 방향 필드에 대한 API 문서 설명 및 기본값이 추가되었습니다.

* **버그 수정**
  * 위치 정보가 있을 때와 없을 때의 로그 검색 동작이 통합되어, 검색 결과의 일관성이 향상되었습니다.

* **리팩터**
  * 위치 기반 및 일반 로그 검색 로직이 하나의 내부 메서드로 통합되어 코드가 간결해졌습니다.
  * 로그 검색 시 미디어 URL이 미리 초기화되어 성능과 안정성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->