### PR TITLE
perf(log): 로그 검색 시 미디어 URL N+1 쿼리 문제 해결

### DIFF
--- a/src/main/java/org/nodystudio/nodybackend/repository/LogRepository.java
+++ b/src/main/java/org/nodystudio/nodybackend/repository/LogRepository.java
@@ -112,7 +112,6 @@ public interface LogRepository extends JpaRepository<Log, Long> {
   /**
    * 특정 사용자의 위치 기반 로그 조회 (본인 비공개 로그 포함)
    */
-  @EntityGraph(attributePaths = { "mediaUrls" })
   @Query(value = """
       SELECT l.*,
              (6371 * acos(cos(radians(:latitude)) * cos(radians(l.latitude)) *
@@ -181,7 +180,7 @@ public interface LogRepository extends JpaRepository<Log, Long> {
   Page<Log> findPublicOrUserLogsOrderByCreatedAtDesc(@Param("userId") Long userId,
       Pageable pageable);
 
-  @Query("SELECT l FROM Log l JOIN FETCH l.mediaUrls WHERE l.id IN :logIds")
+  @Query("SELECT DISTINCT l FROM Log l LEFT JOIN FETCH l.mediaUrls WHERE l.id IN :logIds")
   List<Log> findWithMediaUrlsByIdIn(@Param("logIds") List<Long> logIds);
 
   /**

--- a/src/main/java/org/nodystudio/nodybackend/repository/LogRepository.java
+++ b/src/main/java/org/nodystudio/nodybackend/repository/LogRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.nodystudio.nodybackend.domain.log.Log;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -14,7 +15,8 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * - findByLocationNear: 특정 좌표 반경 내 로그 조회 (Haversine 공식) - findByUserIdOrderByCreatedAtDesc: 사용자별 로그
+ * - findByLocationNear: 특정 좌표 반경 내 로그 조회 (Haversine 공식) -
+ * findByUserIdOrderByCreatedAtDesc: 사용자별 로그
  * 조회 - @Query 어노테이션으로 네이티브 쿼리 작성
  */
 @Repository
@@ -86,7 +88,7 @@ public interface LogRepository extends JpaRepository<Log, Long> {
         AND (6371 * acos(cos(radians(:latitude)) * cos(radians(l.latitude)) *
              cos(radians(l.longitude) - radians(:longitude)) +
              sin(radians(:latitude)) * sin(radians(l.latitude)))) <= :radiusKm
-      ORDER BY 
+      ORDER BY
         CASE WHEN :sortDirection = 'ASC' THEN distance END ASC,
         CASE WHEN :sortDirection = 'DESC' THEN distance END DESC,
         l.created_at DESC
@@ -110,6 +112,7 @@ public interface LogRepository extends JpaRepository<Log, Long> {
   /**
    * 특정 사용자의 위치 기반 로그 조회 (본인 비공개 로그 포함)
    */
+  @EntityGraph(attributePaths = { "mediaUrls" })
   @Query(value = """
       SELECT l.*,
              (6371 * acos(cos(radians(:latitude)) * cos(radians(l.latitude)) *
@@ -123,7 +126,7 @@ public interface LogRepository extends JpaRepository<Log, Long> {
         AND (6371 * acos(cos(radians(:latitude)) * cos(radians(l.latitude)) *
              cos(radians(l.longitude) - radians(:longitude)) +
              sin(radians(:latitude)) * sin(radians(l.latitude)))) <= :radiusKm
-      ORDER BY 
+      ORDER BY
         CASE WHEN :sortDirection = 'ASC' THEN distance END ASC,
         CASE WHEN :sortDirection = 'DESC' THEN distance END DESC,
         l.created_at DESC
@@ -166,15 +169,20 @@ public interface LogRepository extends JpaRepository<Log, Long> {
   /**
    * 공개 로그만 전체 조회 (비로그인 사용자용, 활성화된 로그만)
    */
-  @Query("SELECT l FROM Log l WHERE l.isPublic = true AND l.deactivatedAt IS NULL ORDER BY l.createdAt DESC")
+  @EntityGraph(attributePaths = { "mediaUrls" })
+  @Query(value = "SELECT l FROM Log l WHERE l.isPublic = true AND l.deactivatedAt IS NULL", countQuery = "SELECT COUNT(l) FROM Log l WHERE l.isPublic = true AND l.deactivatedAt IS NULL")
   Page<Log> findByIsPublicTrueOrderByCreatedAtDesc(Pageable pageable);
 
   /**
    * 공개 로그 + 특정 사용자의 비공개 로그 조회 (로그인 사용자용, 활성화된 로그만)
    */
-  @Query("SELECT l FROM Log l WHERE l.deactivatedAt IS NULL AND (l.isPublic = true OR l.user.id = :userId) ORDER BY l.createdAt DESC")
+  @EntityGraph(attributePaths = { "mediaUrls" })
+  @Query(value = "SELECT l FROM Log l WHERE l.deactivatedAt IS NULL AND (l.isPublic = true OR l.user.id = :userId)", countQuery = "SELECT COUNT(l) FROM Log l WHERE l.deactivatedAt IS NULL AND (l.isPublic = true OR l.user.id = :userId)")
   Page<Log> findPublicOrUserLogsOrderByCreatedAtDesc(@Param("userId") Long userId,
       Pageable pageable);
+
+  @Query("SELECT l FROM Log l JOIN FETCH l.mediaUrls WHERE l.id IN :logIds")
+  List<Log> findWithMediaUrlsByIdIn(@Param("logIds") List<Long> logIds);
 
   /**
    * 활성화된 사용자 로그를 모두 조회합니다 (비활성화 작업용).

--- a/src/main/java/org/nodystudio/nodybackend/service/log/LogService.java
+++ b/src/main/java/org/nodystudio/nodybackend/service/log/LogService.java
@@ -1,6 +1,9 @@
 package org.nodystudio.nodybackend.service.log;
 
+import static java.util.stream.Collectors.toMap;
+
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.nodystudio.nodybackend.domain.enums.LogSortField;
@@ -140,11 +143,8 @@ public class LogService {
     // 위치 기반 검색 시 Native Query의 ORDER BY를 사용하므로 Pageable에서 정렬 제외
     Pageable pageable = createPageable(searchRequest, searchRequest.isLocationSearch());
 
-    Page<Log> logs = executeLogSearch(searchRequest, viewer, pageable, searchRequest.isLocationSearch());
-
-    logs.getContent().forEach(log -> {
-      log.getMediaUrls().size();
-    });
+    Page<Log> logs = executeLogSearch(searchRequest, viewer, pageable,
+        searchRequest.isLocationSearch());
 
     log.info("로그 검색 완료 - 총 {}건", logs.getTotalElements());
     return logs.map(LogResponse::from);
@@ -336,7 +336,22 @@ public class LogService {
       boolean isLocationSearch) {
 
     if (isLocationSearch) {
-      return searchByLocation(searchRequest, viewer, pageable);
+      Page<Log> logsWithoutMedia = searchByLocation(searchRequest, viewer, pageable);
+      if (logsWithoutMedia.hasContent()) {
+        List<Long> logIds = logsWithoutMedia.getContent().stream()
+            .map(Log::getId)
+            .toList();
+        List<Log> logsWithMedia = logRepository.findWithMediaUrlsByIdIn(logIds);
+        Map<Long, Log> logMap = logsWithMedia.stream()
+            .collect(toMap(Log::getId, l -> l));
+        logsWithoutMedia.getContent().forEach(log -> {
+          Log logWithMedia = logMap.get(log.getId());
+          if (logWithMedia != null) {
+            log.updateMediaUrls(logWithMedia.getMediaUrls());
+          }
+        });
+      }
+      return logsWithoutMedia;
     }
 
     // 전체 로그 검색


### PR DESCRIPTION
## 📋 작업 개요

로그 검색 API에서 발생하던 미디어 URL 조회 시 N+1 쿼리 문제를 해결하여 성능을 개선했습니다.

## 🔍 문제 상황

### 기존 문제점
- 로그 검색 결과에서 각 로그의 미디어 URL을 조회할 때마다 개별 쿼리 실행
- N개의 로그 검색 시 N+1개의 쿼리 발생 (1개는 로그 조회, N개는 각 로그의 미디어 URL 조회)
- 특히 위치 기반 검색에서 성능 저하가 심각함

### 성능 영향
- 로그 10개 조회 시: 11개 쿼리 실행 (1 + 10)
- 로그 20개 조회 시: 21개 쿼리 실행 (1 + 20)
- 데이터베이스 부하 증가 및 응답 시간 지연

## ✅ 해결 방법

### 1. EntityGraph를 통한 즉시 로딩
```java
@EntityGraph(attributePaths = { "mediaUrls" })
@Query(value = "SELECT l FROM Log l WHERE l.isPublic = true AND l.deactivatedAt IS NULL", 
       countQuery = "SELECT COUNT(l) FROM Log l WHERE l.isPublic = true AND l.deactivatedAt IS NULL")
Page<Log> findByIsPublicTrueOrderByCreatedAtDesc(Pageable pageable);
```

### 2. 배치 조회 메소드 추가
```java
@Query("SELECT l FROM Log l JOIN FETCH l.mediaUrls WHERE l.id IN :logIds")
List<Log> findWithMediaUrlsByIdIn(@Param("logIds") List<Long> logIds);
```

### 3. 위치 기반 검색 최적화
- 위치 검색 후 별도 쿼리로 미디어 URL을 일괄 조회
- Map을 활용한 효율적인 데이터 매핑

## 🔧 주요 변경사항

### LogRepository.java
- `@EntityGraph` import 추가
- `findByLocationNearForUser` 메소드에 `@EntityGraph` 적용
- `findByIsPublicTrueOrderByCreatedAtDesc`와 `findPublicOrUserLogsOrderByCreatedAtDesc`에 `@EntityGraph` 및 `countQuery` 추가
- `findWithMediaUrlsByIdIn` 새 메소드 추가

### LogService.java
- 위치 기반 검색에서 미디어 URL 배치 조회 로직 구현
- 기존 지연 로딩 방식의 forEach 루프 제거
- Map을 활용한 효율적인 데이터 매핑

## 📈 성능 개선 효과

### 쿼리 수 최적화
- **기존**: 로그 N개 조회 시 N+1개 쿼리
- **개선**: 로그 N개 조회 시 최대 2개 쿼리 (로그 조회 1개 + 미디어 URL 배치 조회 1개)

### 예상 성능 향상
- 로그 10개 조회: 11개 → 2개 쿼리 (약 82% 감소)
- 로그 20개 조회: 21개 → 2개 쿼리 (약 90% 감소)
- 데이터베이스 부하 감소 및 응답 속도 향상

## 🧪 테스트 확인사항

### 단위 테스트
- [x] LogRepository 테스트에서 EntityGraph 동작 확인
- [x] LogService의 배치 조회 로직 테스트

### 통합 테스트  
- [x] 위치 기반 로그 검색 API 테스트
- [x] 공개 로그 조회 API 테스트
- [x] 사용자별 로그 조회 API 테스트

## 🔍 코드 리뷰 포인트

### 검토 요청사항
1. **EntityGraph 설정**: 미디어 URL 즉시 로딩 설정이 적절한지 확인
2. **배치 조회 로직**: Map을 활용한 데이터 매핑 로직의 효율성 검토  
3. **쿼리 최적화**: countQuery 추가가 페이징 성능에 미치는 영향 검토
4. **메모리 사용량**: 즉시 로딩으로 인한 메모리 사용량 증가 검토

### 추가 고려사항
- 미디어 URL이 많은 로그의 경우 메모리 사용량 모니터링 필요
- 향후 다른 연관 엔티티에도 비슷한 최적화 적용 검토

## 🚀 배포 후 모니터링 계획

1. **쿼리 실행 횟수 모니터링**
   - 로그 검색 API 호출 시 실제 쿼리 개수 확인
   - 기존 대비 성능 향상 수치 측정

2. **응답 시간 측정**
   - 로그 검색 API 평균 응답 시간 비교
   - 특히 위치 기반 검색 성능 개선 확인

3. **메모리 사용량 추적**
   - 미디어 URL 즉시 로딩으로 인한 메모리 사용량 변화 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **버그 수정**
  * 로그 조회 시 미디어 URL이 누락되는 문제를 개선하여, 위치 기반 로그 검색 결과에 미디어 URL이 올바르게 포함되도록 수정하였습니다.

* **성능 개선**
  * 로그와 관련된 미디어 URL을 한 번에 효율적으로 불러오도록 최적화하여, 검색 속도와 응답 성능이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->