### PR TITLE
perf(log): 위치 기반 로그 검색의 User N+1 쿼리 제거

### DIFF
--- a/src/main/java/org/nodystudio/nodybackend/repository/LogRepository.java
+++ b/src/main/java/org/nodystudio/nodybackend/repository/LogRepository.java
@@ -168,19 +168,19 @@ public interface LogRepository extends JpaRepository<Log, Long> {
   /**
    * 공개 로그만 전체 조회 (비로그인 사용자용, 활성화된 로그만)
    */
-  @EntityGraph(attributePaths = { "mediaUrls" })
+  @EntityGraph(attributePaths = { "mediaUrls", "user" })
   @Query(value = "SELECT l FROM Log l WHERE l.isPublic = true AND l.deactivatedAt IS NULL", countQuery = "SELECT COUNT(l) FROM Log l WHERE l.isPublic = true AND l.deactivatedAt IS NULL")
   Page<Log> findByIsPublicTrueOrderByCreatedAtDesc(Pageable pageable);
 
   /**
    * 공개 로그 + 특정 사용자의 비공개 로그 조회 (로그인 사용자용, 활성화된 로그만)
    */
-  @EntityGraph(attributePaths = { "mediaUrls" })
+  @EntityGraph(attributePaths = { "mediaUrls", "user" })
   @Query(value = "SELECT l FROM Log l WHERE l.deactivatedAt IS NULL AND (l.isPublic = true OR l.user.id = :userId)", countQuery = "SELECT COUNT(l) FROM Log l WHERE l.deactivatedAt IS NULL AND (l.isPublic = true OR l.user.id = :userId)")
   Page<Log> findPublicOrUserLogsOrderByCreatedAtDesc(@Param("userId") Long userId,
       Pageable pageable);
 
-  @Query("SELECT DISTINCT l FROM Log l LEFT JOIN FETCH l.mediaUrls WHERE l.id IN :logIds")
+  @Query("SELECT DISTINCT l FROM Log l JOIN FETCH l.user LEFT JOIN FETCH l.mediaUrls WHERE l.id IN :logIds")
   List<Log> findWithMediaUrlsByIdIn(@Param("logIds") List<Long> logIds);
 
   /**


### PR DESCRIPTION
## 개요
위치 기반 로그 검색(`GET /api/logs`)에서 `User` 연관(작성자 정보) 접근 시 발생하던 N+1 쿼리를 제거/완화했습니다. 또한 `@EntityGraph`가 네이티브 쿼리에서 적용되지 않는 문제 지점을 정리하고, 두 단계 로딩 패턴으로 일관된 패치 전략을 적용했습니다.

## 변경 사항
### JPQL 페이징 경로
- `@EntityGraph(attributePaths = {"mediaUrls", "user"})` 적용으로 `User` 및 `mediaUrls` 즉시 로딩
### 네이티브(위치 검색) 경로
- 페이지 결과의 ID 목록으로 `User + mediaUrls`를 2단계 로딩
- `LEFT JOIN FETCH + DISTINCT`를 사용하여 중복/카디널리티 이슈를 방지
### `@EntityGraph` 제거
- 네이티브 메서드에 붙어있던 동작하지 않는 `@EntityGraph` 제거

## 문제 원인
- `@EntityGraph`는 네이티브 쿼리(`nativeQuery = true`)에 적용되지 않습니다.
- DTO 매핑 시 `log.getUser()` 접근이 지연로딩을 유발하여 N+1 발생 → 2단계 로딩 또는 배치 패치가 필요합니다.
- `@ElementCollection`(`mediaUrls`)은 컬렉션 특성상 조인 시 중복행이 생길 수 있어 `DISTINCT` 처리가 필요합니다.

## 성능 영향
- 위치 기반 검색 시 쿼리 수 감소: `User`와 `mediaUrls`를 일괄 로딩하여 N+1 제거/완화
- JPQL 경로는 `@EntityGraph`로 즉시 로딩되어 추가 쿼리 감소

## 테스트
- 명령: `./gradlew test`
- 결과: 모든 테스트 통과 (BUILD SUCCESSFUL)

## 회귀 위험 및 대응
- 패치 전략 변경으로 인한 중복행 위험을 `DISTINCT`로 방지
- JPQL 경로는 카운트 쿼리 분리로 페이징 정확성 보장




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 성능 개선
  - 공개 로그 피드와 관련 목록 조회 시 작성자 정보와 미디어를 함께 불러오도록 최적화해 초기 로딩과 페이지 전환 속도를 개선했습니다. 스크롤 페이징 시 끊김이 줄어들었습니다.
- 버그 수정
  - 공개 로그 목록에서 작성자 이름/아바타가 간헐적으로 표시되지 않거나 늦게 나타나던 문제를 해소했습니다.
  - 다건 조회에서 작성자 정보 누락으로 정렬/표시가 불안정하던 현상을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->